### PR TITLE
Parallel Execution of 8 cycles of Stream Cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ make benchmark
 
 Note that, when benchmarking, associated data length is always kept 32 -bytes, while variable length ( = L ) plain text is used | L ∈ [64..4096] && L = 2 ^ i.
 
-> Note, in this implementation, 8 consecutive cycles of Grain-128 AEAD stream cipher are executed in parallel.
+> Note, in this implementation, 8 consecutive cycles of Grain-128 AEAD stream cipher are executed in parallel, after cipher internal state is initialized. During execution of initialization phase, 32 consecutive clocks are executed in parallel ( initialization is done by clocking cipher state 512 times ).
 
 ### On AWS Graviton3
 
 ```bash
-2022-08-12T14:43:21+00:00
+2022-08-14T06:07:17+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -124,60 +124,60 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.08, 0.02, 0.01
+Load Average: 0.14, 0.03, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         5237 ns         5237 ns       133578 bytes_per_second=17.4831M/s
-bench_grain_128aead::decrypt/32/64         5315 ns         5315 ns       131702 bytes_per_second=17.2264M/s
-bench_grain_128aead::encrypt/32/128        7679 ns         7679 ns        91182 bytes_per_second=19.8715M/s
-bench_grain_128aead::decrypt/32/128        7912 ns         7912 ns        88459 bytes_per_second=19.2849M/s
-bench_grain_128aead::encrypt/32/256       12552 ns        12552 ns        55768 bytes_per_second=21.8824M/s
-bench_grain_128aead::decrypt/32/256       13110 ns        13110 ns        53398 bytes_per_second=20.9501M/s
-bench_grain_128aead::encrypt/32/512       22280 ns        22280 ns        31420 bytes_per_second=23.2857M/s
-bench_grain_128aead::decrypt/32/512       23503 ns        23503 ns        29785 bytes_per_second=22.0739M/s
-bench_grain_128aead::encrypt/32/1024      41720 ns        41719 ns        16781 bytes_per_second=24.1395M/s
-bench_grain_128aead::decrypt/32/1024      44286 ns        44286 ns        15807 bytes_per_second=22.7406M/s
-bench_grain_128aead::encrypt/32/2048      80594 ns        80590 ns         8686 bytes_per_second=24.6139M/s
-bench_grain_128aead::decrypt/32/2048      85854 ns        85852 ns         8155 bytes_per_second=23.1054M/s
-bench_grain_128aead::encrypt/32/4096     158397 ns       158390 ns         4419 bytes_per_second=24.8549M/s
-bench_grain_128aead::decrypt/32/4096     168921 ns       168916 ns         4144 bytes_per_second=23.3061M/s
+bench_grain_128aead::encrypt/32/64         7939 ns         7939 ns        88196 bytes_per_second=11.5326M/s
+bench_grain_128aead::decrypt/32/64         8216 ns         8216 ns        85203 bytes_per_second=11.1437M/s
+bench_grain_128aead::encrypt/32/128       10372 ns        10372 ns        67486 bytes_per_second=14.7116M/s
+bench_grain_128aead::decrypt/32/128       10818 ns        10818 ns        64707 bytes_per_second=14.1047M/s
+bench_grain_128aead::encrypt/32/256       15211 ns        15211 ns        46024 bytes_per_second=18.0565M/s
+bench_grain_128aead::decrypt/32/256       16018 ns        16017 ns        43697 bytes_per_second=17.1474M/s
+bench_grain_128aead::encrypt/32/512       24851 ns        24850 ns        28168 bytes_per_second=20.8769M/s
+bench_grain_128aead::decrypt/32/512       26413 ns        26412 ns        26502 bytes_per_second=19.6423M/s
+bench_grain_128aead::encrypt/32/1024      44278 ns        44277 ns        15877 bytes_per_second=22.745M/s
+bench_grain_128aead::decrypt/32/1024      46972 ns        46971 ns        14902 bytes_per_second=21.4405M/s
+bench_grain_128aead::encrypt/32/2048      82530 ns        82528 ns         8481 bytes_per_second=24.0359M/s
+bench_grain_128aead::decrypt/32/2048      88755 ns        88753 ns         7887 bytes_per_second=22.3502M/s
+bench_grain_128aead::encrypt/32/4096     159410 ns       159406 ns         4391 bytes_per_second=24.6965M/s
+bench_grain_128aead::decrypt/32/4096     171819 ns       171815 ns         4074 bytes_per_second=22.9128M/s
 ```
 
 ### On AWS Graviton2
 
 ```bash
-2022-08-12T14:42:19+00:00
+2022-08-14T06:06:26+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.15, 0.03, 0.01
+Load Average: 0.08, 0.02, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        11794 ns        11794 ns        59337 bytes_per_second=7.76266M/s
-bench_grain_128aead::decrypt/32/64        11812 ns        11811 ns        59273 bytes_per_second=7.7513M/s
-bench_grain_128aead::encrypt/32/128       17476 ns        17475 ns        40054 bytes_per_second=8.73154M/s
-bench_grain_128aead::decrypt/32/128       17491 ns        17491 ns        40020 bytes_per_second=8.72391M/s
-bench_grain_128aead::encrypt/32/256       28839 ns        28839 ns        24272 bytes_per_second=9.52378M/s
-bench_grain_128aead::decrypt/32/256       28857 ns        28856 ns        24259 bytes_per_second=9.51823M/s
-bench_grain_128aead::encrypt/32/512       51567 ns        51567 ns        13574 bytes_per_second=10.0607M/s
-bench_grain_128aead::decrypt/32/512       51582 ns        51582 ns        13570 bytes_per_second=10.0578M/s
-bench_grain_128aead::encrypt/32/1024      97024 ns        97022 ns         7214 bytes_per_second=10.3799M/s
-bench_grain_128aead::decrypt/32/1024      97038 ns        97036 ns         7214 bytes_per_second=10.3784M/s
-bench_grain_128aead::encrypt/32/2048     187944 ns       187939 ns         3724 bytes_per_second=10.5547M/s
-bench_grain_128aead::decrypt/32/2048     187948 ns       187945 ns         3725 bytes_per_second=10.5544M/s
-bench_grain_128aead::encrypt/32/4096     369809 ns       369803 ns         1893 bytes_per_second=10.6456M/s
-bench_grain_128aead::decrypt/32/4096     369808 ns       369802 ns         1893 bytes_per_second=10.6456M/s
+bench_grain_128aead::encrypt/32/64        11443 ns        11443 ns        61134 bytes_per_second=8.0006M/s
+bench_grain_128aead::decrypt/32/64        11454 ns        11454 ns        61115 bytes_per_second=7.99341M/s
+bench_grain_128aead::encrypt/32/128       17126 ns        17126 ns        40875 bytes_per_second=8.90969M/s
+bench_grain_128aead::decrypt/32/128       17136 ns        17135 ns        40849 bytes_per_second=8.90481M/s
+bench_grain_128aead::encrypt/32/256       28489 ns        28489 ns        24571 bytes_per_second=9.64093M/s
+bench_grain_128aead::decrypt/32/256       28500 ns        28500 ns        24561 bytes_per_second=9.63716M/s
+bench_grain_128aead::encrypt/32/512       51218 ns        51217 ns        13667 bytes_per_second=10.1295M/s
+bench_grain_128aead::decrypt/32/512       51231 ns        51228 ns        13665 bytes_per_second=10.1272M/s
+bench_grain_128aead::encrypt/32/1024      96671 ns        96670 ns         7240 bytes_per_second=10.4177M/s
+bench_grain_128aead::decrypt/32/1024      96690 ns        96687 ns         7240 bytes_per_second=10.4159M/s
+bench_grain_128aead::encrypt/32/2048     187590 ns       187585 ns         3732 bytes_per_second=10.5746M/s
+bench_grain_128aead::decrypt/32/2048     187619 ns       187614 ns         3731 bytes_per_second=10.573M/s
+bench_grain_128aead::encrypt/32/4096     369432 ns       369426 ns         1895 bytes_per_second=10.6564M/s
+bench_grain_128aead::decrypt/32/4096     369445 ns       369433 ns         1895 bytes_per_second=10.6562M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-08-12T18:30:05+04:00
+2022-08-14T10:04:14+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -185,30 +185,30 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.62, 1.47, 1.68
+Load Average: 1.71, 2.33, 2.33
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         6302 ns         6292 ns       104808 bytes_per_second=14.5499M/s
-bench_grain_128aead::decrypt/32/64         6252 ns         6247 ns       110141 bytes_per_second=14.6556M/s
-bench_grain_128aead::encrypt/32/128        9223 ns         9217 ns        74051 bytes_per_second=16.5542M/s
-bench_grain_128aead::decrypt/32/128        9607 ns         9599 ns        73394 bytes_per_second=15.8954M/s
-bench_grain_128aead::encrypt/32/256       15409 ns        15402 ns        45015 bytes_per_second=17.8324M/s
-bench_grain_128aead::decrypt/32/256       15625 ns        15611 ns        43482 bytes_per_second=17.5937M/s
-bench_grain_128aead::encrypt/32/512       27912 ns        27893 ns        25013 bytes_per_second=18.5995M/s
-bench_grain_128aead::decrypt/32/512       29477 ns        29428 ns        23936 bytes_per_second=17.6297M/s
-bench_grain_128aead::encrypt/32/1024      51964 ns        51938 ns        13170 bytes_per_second=19.3902M/s
-bench_grain_128aead::decrypt/32/1024      51805 ns        51790 ns        13135 bytes_per_second=19.4456M/s
-bench_grain_128aead::encrypt/32/2048     100100 ns       100024 ns         6886 bytes_per_second=19.8317M/s
-bench_grain_128aead::decrypt/32/2048     101439 ns       101336 ns         6857 bytes_per_second=19.5748M/s
-bench_grain_128aead::encrypt/32/4096     195531 ns       195455 ns         3556 bytes_per_second=20.1416M/s
-bench_grain_128aead::decrypt/32/4096     199211 ns       199083 ns         3485 bytes_per_second=19.7745M/s
+bench_grain_128aead::encrypt/32/64         5431 ns         5428 ns       120159 bytes_per_second=16.8669M/s
+bench_grain_128aead::decrypt/32/64         5443 ns         5438 ns       121926 bytes_per_second=16.837M/s
+bench_grain_128aead::encrypt/32/128        8501 ns         8493 ns        78511 bytes_per_second=17.9655M/s
+bench_grain_128aead::decrypt/32/128        8652 ns         8620 ns        81125 bytes_per_second=17.7015M/s
+bench_grain_128aead::encrypt/32/256       16225 ns        16010 ns        45959 bytes_per_second=17.1549M/s
+bench_grain_128aead::decrypt/32/256       16612 ns        16383 ns        41319 bytes_per_second=16.7652M/s
+bench_grain_128aead::encrypt/32/512       30356 ns        29256 ns        25416 bytes_per_second=17.7328M/s
+bench_grain_128aead::decrypt/32/512       27383 ns        27331 ns        24107 bytes_per_second=18.9822M/s
+bench_grain_128aead::encrypt/32/1024      55254 ns        54708 ns        13409 bytes_per_second=18.4081M/s
+bench_grain_128aead::decrypt/32/1024      55436 ns        54904 ns        12272 bytes_per_second=18.3425M/s
+bench_grain_128aead::encrypt/32/2048     103929 ns       103547 ns         6767 bytes_per_second=19.1569M/s
+bench_grain_128aead::decrypt/32/2048     111206 ns       108785 ns         6634 bytes_per_second=18.2346M/s
+bench_grain_128aead::encrypt/32/4096     201916 ns       201604 ns         3353 bytes_per_second=19.5272M/s
+bench_grain_128aead::decrypt/32/4096     213681 ns       211716 ns         3439 bytes_per_second=18.5945M/s
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
 
 ```bash
-2022-08-12T14:41:09+00:00
+2022-08-14T06:05:20+00:00
 Running ./bench/a.out
 Run on (4 X 2300 MHz CPU s)
 CPU Caches:
@@ -216,24 +216,24 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.04, 0.01, 0.00
+Load Average: 0.14, 0.03, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        11504 ns        11503 ns        60790 bytes_per_second=7.95909M/s
-bench_grain_128aead::decrypt/32/64        11120 ns        11119 ns        63009 bytes_per_second=8.23411M/s
-bench_grain_128aead::encrypt/32/128       16878 ns        16876 ns        41476 bytes_per_second=9.04184M/s
-bench_grain_128aead::decrypt/32/128       16357 ns        16356 ns        42814 bytes_per_second=9.32891M/s
-bench_grain_128aead::encrypt/32/256       27481 ns        27481 ns        25417 bytes_per_second=9.99446M/s
-bench_grain_128aead::decrypt/32/256       26800 ns        26798 ns        26091 bytes_per_second=10.2491M/s
-bench_grain_128aead::encrypt/32/512       48620 ns        48620 ns        14399 bytes_per_second=10.6704M/s
-bench_grain_128aead::decrypt/32/512       47531 ns        47530 ns        14730 bytes_per_second=10.9151M/s
-bench_grain_128aead::encrypt/32/1024      90885 ns        90886 ns         7706 bytes_per_second=11.0807M/s
-bench_grain_128aead::decrypt/32/1024      89048 ns        89047 ns         7863 bytes_per_second=11.3095M/s
-bench_grain_128aead::encrypt/32/2048     175603 ns       175599 ns         3987 bytes_per_second=11.2965M/s
-bench_grain_128aead::decrypt/32/2048     172172 ns       172164 ns         3961 bytes_per_second=11.5218M/s
-bench_grain_128aead::encrypt/32/4096     345171 ns       345161 ns         2026 bytes_per_second=11.4056M/s
-bench_grain_128aead::decrypt/32/4096     338591 ns       338576 ns         2067 bytes_per_second=11.6274M/s
+bench_grain_128aead::encrypt/32/64        14046 ns        14045 ns        49790 bytes_per_second=6.51851M/s
+bench_grain_128aead::decrypt/32/64        13666 ns        13666 ns        51215 bytes_per_second=6.69953M/s
+bench_grain_128aead::encrypt/32/128       19346 ns        19346 ns        36204 bytes_per_second=7.88721M/s
+bench_grain_128aead::decrypt/32/128       18892 ns        18892 ns        37063 bytes_per_second=8.07689M/s
+bench_grain_128aead::encrypt/32/256       29962 ns        29962 ns        23377 bytes_per_second=9.16683M/s
+bench_grain_128aead::decrypt/32/256       29288 ns        29289 ns        23906 bytes_per_second=9.37763M/s
+bench_grain_128aead::encrypt/32/512       51059 ns        51056 ns        13697 bytes_per_second=10.1614M/s
+bench_grain_128aead::decrypt/32/512       50028 ns        50029 ns        10000 bytes_per_second=10.3701M/s
+bench_grain_128aead::encrypt/32/1024      93829 ns        93830 ns         7491 bytes_per_second=10.7331M/s
+bench_grain_128aead::decrypt/32/1024      91690 ns        91690 ns         7646 bytes_per_second=10.9835M/s
+bench_grain_128aead::encrypt/32/2048     178232 ns       178233 ns         3934 bytes_per_second=11.1295M/s
+bench_grain_128aead::decrypt/32/2048     174480 ns       174457 ns         4010 bytes_per_second=11.3704M/s
+bench_grain_128aead::encrypt/32/4096     346932 ns       346907 ns         2019 bytes_per_second=11.3482M/s
+bench_grain_128aead::decrypt/32/4096     340194 ns       340168 ns         2058 bytes_per_second=11.573M/s
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -109,12 +109,14 @@ make benchmark
 
 > For disabling CPU scaling when benchmarking, see [this](https://github.com/google/benchmark/blob/60b16f1/docs/user_guide.md#disabling-cpu-frequency-scaling)
 
-Note that, when benchmarking, associated data length is always kept 32 -bytes, while variable length plain text is used | L ∈ [64..4096] && L = 2 ^ i.
+Note that, when benchmarking, associated data length is always kept 32 -bytes, while variable length ( = L ) plain text is used | L ∈ [64..4096] && L = 2 ^ i.
+
+> Note, in this implementation, 8 consecutive cycles of Grain-128 AEAD stream cipher are executed in parallel.
 
 ### On AWS Graviton3
 
 ```bash
-2022-08-09T11:50:34+00:00
+2022-08-12T14:43:21+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -122,60 +124,60 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.32, 0.12, 0.04
+Load Average: 0.08, 0.02, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        40110 ns        40110 ns        17451 bytes_per_second=2.28256M/s
-bench_grain_128aead::decrypt/32/64        39739 ns        39738 ns        17613 bytes_per_second=2.30389M/s
-bench_grain_128aead::encrypt/32/128       61617 ns        61616 ns        11359 bytes_per_second=2.47644M/s
-bench_grain_128aead::decrypt/32/128       60915 ns        60914 ns        11490 bytes_per_second=2.50499M/s
-bench_grain_128aead::encrypt/32/256      104573 ns       104571 ns         6694 bytes_per_second=2.62652M/s
-bench_grain_128aead::decrypt/32/256      103254 ns       103252 ns         6780 bytes_per_second=2.66007M/s
-bench_grain_128aead::encrypt/32/512      190525 ns       190522 ns         3674 bytes_per_second=2.72305M/s
-bench_grain_128aead::decrypt/32/512      187922 ns       187911 ns         3725 bytes_per_second=2.76088M/s
-bench_grain_128aead::encrypt/32/1024     362795 ns       362789 ns         1930 bytes_per_second=2.77594M/s
-bench_grain_128aead::decrypt/32/1024     357358 ns       357344 ns         1959 bytes_per_second=2.81824M/s
-bench_grain_128aead::encrypt/32/2048     707411 ns       707366 ns          990 bytes_per_second=2.80427M/s
-bench_grain_128aead::decrypt/32/2048     695944 ns       695926 ns         1006 bytes_per_second=2.85036M/s
-bench_grain_128aead::encrypt/32/4096    1395791 ns      1395752 ns          502 bytes_per_second=2.82053M/s
-bench_grain_128aead::decrypt/32/4096    1373470 ns      1373435 ns          510 bytes_per_second=2.86637M/s
+bench_grain_128aead::encrypt/32/64         5237 ns         5237 ns       133578 bytes_per_second=17.4831M/s
+bench_grain_128aead::decrypt/32/64         5315 ns         5315 ns       131702 bytes_per_second=17.2264M/s
+bench_grain_128aead::encrypt/32/128        7679 ns         7679 ns        91182 bytes_per_second=19.8715M/s
+bench_grain_128aead::decrypt/32/128        7912 ns         7912 ns        88459 bytes_per_second=19.2849M/s
+bench_grain_128aead::encrypt/32/256       12552 ns        12552 ns        55768 bytes_per_second=21.8824M/s
+bench_grain_128aead::decrypt/32/256       13110 ns        13110 ns        53398 bytes_per_second=20.9501M/s
+bench_grain_128aead::encrypt/32/512       22280 ns        22280 ns        31420 bytes_per_second=23.2857M/s
+bench_grain_128aead::decrypt/32/512       23503 ns        23503 ns        29785 bytes_per_second=22.0739M/s
+bench_grain_128aead::encrypt/32/1024      41720 ns        41719 ns        16781 bytes_per_second=24.1395M/s
+bench_grain_128aead::decrypt/32/1024      44286 ns        44286 ns        15807 bytes_per_second=22.7406M/s
+bench_grain_128aead::encrypt/32/2048      80594 ns        80590 ns         8686 bytes_per_second=24.6139M/s
+bench_grain_128aead::decrypt/32/2048      85854 ns        85852 ns         8155 bytes_per_second=23.1054M/s
+bench_grain_128aead::encrypt/32/4096     158397 ns       158390 ns         4419 bytes_per_second=24.8549M/s
+bench_grain_128aead::decrypt/32/4096     168921 ns       168916 ns         4144 bytes_per_second=23.3061M/s
 ```
 
 ### On AWS Graviton2
 
 ```bash
-2022-08-09T11:47:28+00:00
+2022-08-12T14:42:19+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.33, 0.15, 0.06
+Load Average: 0.15, 0.03, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        89278 ns        89277 ns         7835 bytes_per_second=1050.11k/s
-bench_grain_128aead::decrypt/32/64        88187 ns        88186 ns         7938 bytes_per_second=1063.1k/s
-bench_grain_128aead::encrypt/32/128      138527 ns       138524 ns         5053 bytes_per_second=1.10153M/s
-bench_grain_128aead::decrypt/32/128      136314 ns       136313 ns         5135 bytes_per_second=1.1194M/s
-bench_grain_128aead::encrypt/32/256      237025 ns       237021 ns         2953 bytes_per_second=1.15879M/s
-bench_grain_128aead::decrypt/32/256      232573 ns       232572 ns         3010 bytes_per_second=1.18096M/s
-bench_grain_128aead::encrypt/32/512      434032 ns       434011 ns         1613 bytes_per_second=1.19536M/s
-bench_grain_128aead::decrypt/32/512      425106 ns       425096 ns         1647 bytes_per_second=1.22043M/s
-bench_grain_128aead::encrypt/32/1024     827995 ns       827980 ns          845 bytes_per_second=1.21631M/s
-bench_grain_128aead::decrypt/32/1024     810133 ns       810128 ns          864 bytes_per_second=1.24311M/s
-bench_grain_128aead::encrypt/32/2048    1616020 ns      1615947 ns          433 bytes_per_second=1.22754M/s
-bench_grain_128aead::decrypt/32/2048    1580210 ns      1580201 ns          443 bytes_per_second=1.25531M/s
-bench_grain_128aead::encrypt/32/4096    3191949 ns      3191907 ns          219 bytes_per_second=1.23336M/s
-bench_grain_128aead::decrypt/32/4096    3120435 ns      3120414 ns          224 bytes_per_second=1.26162M/s
+bench_grain_128aead::encrypt/32/64        11794 ns        11794 ns        59337 bytes_per_second=7.76266M/s
+bench_grain_128aead::decrypt/32/64        11812 ns        11811 ns        59273 bytes_per_second=7.7513M/s
+bench_grain_128aead::encrypt/32/128       17476 ns        17475 ns        40054 bytes_per_second=8.73154M/s
+bench_grain_128aead::decrypt/32/128       17491 ns        17491 ns        40020 bytes_per_second=8.72391M/s
+bench_grain_128aead::encrypt/32/256       28839 ns        28839 ns        24272 bytes_per_second=9.52378M/s
+bench_grain_128aead::decrypt/32/256       28857 ns        28856 ns        24259 bytes_per_second=9.51823M/s
+bench_grain_128aead::encrypt/32/512       51567 ns        51567 ns        13574 bytes_per_second=10.0607M/s
+bench_grain_128aead::decrypt/32/512       51582 ns        51582 ns        13570 bytes_per_second=10.0578M/s
+bench_grain_128aead::encrypt/32/1024      97024 ns        97022 ns         7214 bytes_per_second=10.3799M/s
+bench_grain_128aead::decrypt/32/1024      97038 ns        97036 ns         7214 bytes_per_second=10.3784M/s
+bench_grain_128aead::encrypt/32/2048     187944 ns       187939 ns         3724 bytes_per_second=10.5547M/s
+bench_grain_128aead::decrypt/32/2048     187948 ns       187945 ns         3725 bytes_per_second=10.5544M/s
+bench_grain_128aead::encrypt/32/4096     369809 ns       369803 ns         1893 bytes_per_second=10.6456M/s
+bench_grain_128aead::decrypt/32/4096     369808 ns       369802 ns         1893 bytes_per_second=10.6456M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-08-09T16:26:39+04:00
+2022-08-12T18:30:05+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -183,30 +185,30 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.59, 1.68, 1.58
+Load Average: 1.62, 1.47, 1.68
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        49788 ns        48821 ns        14725 bytes_per_second=1.87528M/s
-bench_grain_128aead::decrypt/32/64        49355 ns        48474 ns        13653 bytes_per_second=1.88869M/s
-bench_grain_128aead::encrypt/32/128       73212 ns        72111 ns         9189 bytes_per_second=2.11602M/s
-bench_grain_128aead::decrypt/32/128       76150 ns        74212 ns         9597 bytes_per_second=2.05612M/s
-bench_grain_128aead::encrypt/32/256      119537 ns       118529 ns         5785 bytes_per_second=2.31721M/s
-bench_grain_128aead::decrypt/32/256      120119 ns       118693 ns         5804 bytes_per_second=2.31402M/s
-bench_grain_128aead::encrypt/32/512      217267 ns       214896 ns         3267 bytes_per_second=2.41419M/s
-bench_grain_128aead::decrypt/32/512      216218 ns       213855 ns         3292 bytes_per_second=2.42594M/s
-bench_grain_128aead::encrypt/32/1024     420431 ns       413424 ns         1728 bytes_per_second=2.43595M/s
-bench_grain_128aead::decrypt/32/1024     420876 ns       412820 ns         1658 bytes_per_second=2.43951M/s
-bench_grain_128aead::encrypt/32/2048     799828 ns       790757 ns          835 bytes_per_second=2.50854M/s
-bench_grain_128aead::decrypt/32/2048     864628 ns       838243 ns          865 bytes_per_second=2.36643M/s
-bench_grain_128aead::encrypt/32/4096    1625769 ns      1597487 ns          423 bytes_per_second=2.46435M/s
-bench_grain_128aead::decrypt/32/4096    1638923 ns      1602030 ns          439 bytes_per_second=2.45736M/s
+bench_grain_128aead::encrypt/32/64         6302 ns         6292 ns       104808 bytes_per_second=14.5499M/s
+bench_grain_128aead::decrypt/32/64         6252 ns         6247 ns       110141 bytes_per_second=14.6556M/s
+bench_grain_128aead::encrypt/32/128        9223 ns         9217 ns        74051 bytes_per_second=16.5542M/s
+bench_grain_128aead::decrypt/32/128        9607 ns         9599 ns        73394 bytes_per_second=15.8954M/s
+bench_grain_128aead::encrypt/32/256       15409 ns        15402 ns        45015 bytes_per_second=17.8324M/s
+bench_grain_128aead::decrypt/32/256       15625 ns        15611 ns        43482 bytes_per_second=17.5937M/s
+bench_grain_128aead::encrypt/32/512       27912 ns        27893 ns        25013 bytes_per_second=18.5995M/s
+bench_grain_128aead::decrypt/32/512       29477 ns        29428 ns        23936 bytes_per_second=17.6297M/s
+bench_grain_128aead::encrypt/32/1024      51964 ns        51938 ns        13170 bytes_per_second=19.3902M/s
+bench_grain_128aead::decrypt/32/1024      51805 ns        51790 ns        13135 bytes_per_second=19.4456M/s
+bench_grain_128aead::encrypt/32/2048     100100 ns       100024 ns         6886 bytes_per_second=19.8317M/s
+bench_grain_128aead::decrypt/32/2048     101439 ns       101336 ns         6857 bytes_per_second=19.5748M/s
+bench_grain_128aead::encrypt/32/4096     195531 ns       195455 ns         3556 bytes_per_second=20.1416M/s
+bench_grain_128aead::decrypt/32/4096     199211 ns       199083 ns         3485 bytes_per_second=19.7745M/s
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
 
 ```bash
-2022-08-09T12:28:52+00:00
+2022-08-12T14:41:09+00:00
 Running ./bench/a.out
 Run on (4 X 2300 MHz CPU s)
 CPU Caches:
@@ -214,24 +216,24 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.18, 0.08, 0.03
+Load Average: 0.04, 0.01, 0.00
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64       118728 ns       118725 ns         5895 bytes_per_second=789.642k/s
-bench_grain_128aead::decrypt/32/64       115951 ns       115948 ns         6033 bytes_per_second=808.551k/s
-bench_grain_128aead::encrypt/32/128      183156 ns       183142 ns         3823 bytes_per_second=853.164k/s
-bench_grain_128aead::decrypt/32/128      177456 ns       177438 ns         3941 bytes_per_second=880.59k/s
-bench_grain_128aead::encrypt/32/256      312031 ns       312014 ns         2244 bytes_per_second=901.403k/s
-bench_grain_128aead::decrypt/32/256      300724 ns       300693 ns         2328 bytes_per_second=935.339k/s
-bench_grain_128aead::encrypt/32/512      569837 ns       569800 ns         1228 bytes_per_second=932.345k/s
-bench_grain_128aead::decrypt/32/512      547200 ns       547153 ns         1280 bytes_per_second=970.935k/s
-bench_grain_128aead::encrypt/32/1024    1085490 ns      1085492 ns          645 bytes_per_second=950.03k/s
-bench_grain_128aead::decrypt/32/1024    1040005 ns      1039991 ns          673 bytes_per_second=991.595k/s
-bench_grain_128aead::encrypt/32/2048    2118801 ns      2118742 ns          331 bytes_per_second=958.706k/s
-bench_grain_128aead::decrypt/32/2048    2025749 ns      2025582 ns          345 bytes_per_second=1002.8k/s
-bench_grain_128aead::encrypt/32/4096    4177143 ns      4177052 ns          168 bytes_per_second=965.094k/s
-bench_grain_128aead::decrypt/32/4096    3994538 ns      3994287 ns          175 bytes_per_second=1009.25k/s
+bench_grain_128aead::encrypt/32/64        11504 ns        11503 ns        60790 bytes_per_second=7.95909M/s
+bench_grain_128aead::decrypt/32/64        11120 ns        11119 ns        63009 bytes_per_second=8.23411M/s
+bench_grain_128aead::encrypt/32/128       16878 ns        16876 ns        41476 bytes_per_second=9.04184M/s
+bench_grain_128aead::decrypt/32/128       16357 ns        16356 ns        42814 bytes_per_second=9.32891M/s
+bench_grain_128aead::encrypt/32/256       27481 ns        27481 ns        25417 bytes_per_second=9.99446M/s
+bench_grain_128aead::decrypt/32/256       26800 ns        26798 ns        26091 bytes_per_second=10.2491M/s
+bench_grain_128aead::encrypt/32/512       48620 ns        48620 ns        14399 bytes_per_second=10.6704M/s
+bench_grain_128aead::decrypt/32/512       47531 ns        47530 ns        14730 bytes_per_second=10.9151M/s
+bench_grain_128aead::encrypt/32/1024      90885 ns        90886 ns         7706 bytes_per_second=11.0807M/s
+bench_grain_128aead::decrypt/32/1024      89048 ns        89047 ns         7863 bytes_per_second=11.3095M/s
+bench_grain_128aead::encrypt/32/2048     175603 ns       175599 ns         3987 bytes_per_second=11.2965M/s
+bench_grain_128aead::decrypt/32/2048     172172 ns       172164 ns         3961 bytes_per_second=11.5218M/s
+bench_grain_128aead::encrypt/32/4096     345171 ns       345161 ns         2026 bytes_per_second=11.4056M/s
+bench_grain_128aead::decrypt/32/4096     338591 ns       338576 ns         2067 bytes_per_second=11.6274M/s
 ```
 
 ## Usage

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -58,54 +58,54 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
   std::memcpy(st->lfsr, nonce, 12);
   std::memcpy(st->lfsr + 12, lfsr32, 4);
 
-  for (size_t t = 0; t < 320; t++) {
-    const uint8_t yt = grain_128::ksb(st);
+  for (size_t t = 0; t < 40; t++) {
+    const uint8_t yt = grain_128::ksb8(st);
 
-    const uint8_t s127 = grain_128::l(st);
-    const uint8_t b127 = grain_128::f(st);
+    const uint8_t s120 = grain_128::l8(st);
+    const uint8_t b120 = grain_128::f8(st);
 
-    grain_128::update_lfsr(st, s127 ^ yt);
-    grain_128::update_nfsr(st, b127 ^ yt);
+    grain_128::update_lfsr8(st, s120 ^ yt);
+    grain_128::update_nfsr8(st, b120 ^ yt);
   }
 
-  for (size_t t = 0; t < 64; t++) {
-    const size_t ta = t + 64;
+  for (size_t t = 0; t < 8; t++) {
+    const size_t ta = t + 8;
     const size_t tb = t;
 
-    const uint8_t ka = grain_128::get_bit(key, grain_128::compute_index(ta));
-    const uint8_t kb = grain_128::get_bit(key, grain_128::compute_index(tb));
+    const uint8_t ka = key[ta];
+    const uint8_t kb = key[tb];
 
-    const uint8_t yt = grain_128::ksb(st);
+    const uint8_t yt = grain_128::ksb8(st);
 
-    const uint8_t s127 = grain_128::l(st);
-    const uint8_t b127 = grain_128::f(st);
+    const uint8_t s120 = grain_128::l8(st);
+    const uint8_t b120 = grain_128::f8(st);
 
-    grain_128::update_lfsr(st, s127 ^ yt ^ ka);
-    grain_128::update_nfsr(st, b127 ^ yt ^ kb);
+    grain_128::update_lfsr8(st, s120 ^ yt ^ ka);
+    grain_128::update_nfsr8(st, b120 ^ yt ^ kb);
   }
 
-  for (size_t t = 0; t < 64; t++) {
-    const uint8_t yt = grain_128::ksb(st);
+  for (size_t t = 0; t < 8; t++) {
+    const uint8_t yt = grain_128::ksb8(st);
 
-    grain_128::set_bit(st->acc, yt, grain_128::compute_index(t));
+    st->acc[t] = yt;
 
-    const uint8_t s127 = grain_128::l(st);
-    const uint8_t b127 = grain_128::f(st);
+    const uint8_t s120 = grain_128::l8(st);
+    const uint8_t b120 = grain_128::f8(st);
 
-    grain_128::update_lfsr(st, s127);
-    grain_128::update_nfsr(st, b127);
+    grain_128::update_lfsr8(st, s120);
+    grain_128::update_nfsr8(st, b120);
   }
 
-  for (size_t t = 0; t < 64; t++) {
-    const uint8_t yt = grain_128::ksb(st);
+  for (size_t t = 0; t < 8; t++) {
+    const uint8_t yt = grain_128::ksb8(st);
 
-    grain_128::set_bit(st->sreg, yt, grain_128::compute_index(t));
+    st->sreg[t] = yt;
 
-    const uint8_t s127 = grain_128::l(st);
-    const uint8_t b127 = grain_128::f(st);
+    const uint8_t s120 = grain_128::l8(st);
+    const uint8_t b120 = grain_128::f8(st);
 
-    grain_128::update_lfsr(st, s127);
-    grain_128::update_nfsr(st, b127);
+    grain_128::update_lfsr8(st, s120);
+    grain_128::update_nfsr8(st, b120);
   }
 }
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -105,14 +105,21 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
     const size_t ta = toff + 8;
     const size_t tb = toff + 0;
 
-    const uint32_t ka = static_cast<uint32_t>(key[ta ^ 3] << 24) |
-                        static_cast<uint32_t>(key[ta ^ 2] << 16) |
-                        static_cast<uint32_t>(key[ta ^ 1] << 8) |
-                        static_cast<uint32_t>(key[ta ^ 0] << 0);
-    const uint32_t kb = static_cast<uint32_t>(key[tb ^ 3] << 24) |
-                        static_cast<uint32_t>(key[tb ^ 2] << 16) |
-                        static_cast<uint32_t>(key[tb ^ 1] << 8) |
-                        static_cast<uint32_t>(key[tb ^ 0] << 0);
+    uint32_t ka, kb;
+
+    if (std::endian::native == std::endian::little) {
+      std::memcpy(&ka, key + ta, 4);
+      std::memcpy(&kb, key + tb, 4);
+    } else {
+      ka = static_cast<uint32_t>(key[ta ^ 3] << 24) |
+           static_cast<uint32_t>(key[ta ^ 2] << 16) |
+           static_cast<uint32_t>(key[ta ^ 1] << 8) |
+           static_cast<uint32_t>(key[ta ^ 0] << 0);
+      kb = static_cast<uint32_t>(key[tb ^ 3] << 24) |
+           static_cast<uint32_t>(key[tb ^ 2] << 16) |
+           static_cast<uint32_t>(key[tb ^ 1] << 8) |
+           static_cast<uint32_t>(key[tb ^ 0] << 0);
+    }
 
     const uint32_t yt = grain_128::ksbx32(st);
 
@@ -128,10 +135,14 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
 
     const size_t toff = t << 2;
 
-    st->acc[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
-    st->acc[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
-    st->acc[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
-    st->acc[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+    if constexpr (std::endian::native == std::endian::little) {
+      std::memcpy(st->acc + toff, &yt, 4);
+    } else {
+      st->acc[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
+      st->acc[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
+      st->acc[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
+      st->acc[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+    }
 
     const uint32_t s96 = grain_128::lx32(st);
     const uint32_t b96 = grain_128::fx32(st);
@@ -145,10 +156,14 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
 
     const size_t toff = t << 2;
 
-    st->sreg[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
-    st->sreg[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
-    st->sreg[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
-    st->sreg[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+    if constexpr (std::endian::native == std::endian::little) {
+      std::memcpy(st->sreg + toff, &yt, 4);
+    } else {
+      st->sreg[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
+      st->sreg[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
+      st->sreg[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
+      st->sreg[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+    }
 
     const uint32_t s96 = grain_128::lx32(st);
     const uint32_t b96 = grain_128::fx32(st);

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -1,7 +1,5 @@
 #pragma once
 #include "grain_128.hpp"
-#include <bit>
-#include <cstring>
 
 // Grain-128 Authenticated Encryption with Associated Data
 namespace aead {
@@ -90,13 +88,13 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
   std::memcpy(st->lfsr + 12, lfsr32, 4);
 
   for (size_t t = 0; t < 40; t++) {
-    const uint8_t yt = grain_128::ksb8(st);
+    const uint8_t yt = grain_128::ksb(st);
 
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120 ^ yt);
-    grain_128::update_nfsr8(st, b120 ^ yt);
+    grain_128::update_lfsr(st, s120 ^ yt);
+    grain_128::update_nfsr(st, b120 ^ yt);
   }
 
   for (size_t t = 0; t < 8; t++) {
@@ -106,37 +104,37 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
     const uint8_t ka = key[ta];
     const uint8_t kb = key[tb];
 
-    const uint8_t yt = grain_128::ksb8(st);
+    const uint8_t yt = grain_128::ksb(st);
 
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120 ^ yt ^ ka);
-    grain_128::update_nfsr8(st, b120 ^ yt ^ kb);
+    grain_128::update_lfsr(st, s120 ^ yt ^ ka);
+    grain_128::update_nfsr(st, b120 ^ yt ^ kb);
   }
 
   for (size_t t = 0; t < 8; t++) {
-    const uint8_t yt = grain_128::ksb8(st);
+    const uint8_t yt = grain_128::ksb(st);
 
     st->acc[t] = yt;
 
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120);
-    grain_128::update_nfsr8(st, b120);
+    grain_128::update_lfsr(st, s120);
+    grain_128::update_nfsr(st, b120);
   }
 
   for (size_t t = 0; t < 8; t++) {
-    const uint8_t yt = grain_128::ksb8(st);
+    const uint8_t yt = grain_128::ksb(st);
 
     st->sreg[t] = yt;
 
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120);
-    grain_128::update_nfsr8(st, b120);
+    grain_128::update_lfsr(st, s120);
+    grain_128::update_nfsr(st, b120);
   }
 }
 
@@ -160,24 +158,24 @@ auth_associated_data(
   // Authenticate DER encoded length of associated data
 
   for (size_t i = 0; i < der_len; i++) {
-    const uint8_t yt0 = grain_128::ksb8(st);
+    const uint8_t yt0 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
-    const uint8_t yt1 = grain_128::ksb8(st);
+    const uint8_t yt1 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
     const auto splitted = split_bits(yt0, yt1);
@@ -188,24 +186,24 @@ auth_associated_data(
   // Authenticate associated data bits
 
   for (size_t i = 0; i < dlen; i++) {
-    const uint8_t yt0 = grain_128::ksb8(st);
+    const uint8_t yt0 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
-    const uint8_t yt1 = grain_128::ksb8(st);
+    const uint8_t yt1 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
     const auto splitted = split_bits(yt0, yt1);
@@ -228,24 +226,24 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
   // Encrypt and authenticate plain text bits
 
   for (size_t i = 0; i < ctlen; i++) {
-    const uint8_t yt0 = grain_128::ksb8(st);
+    const uint8_t yt0 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
-    const uint8_t yt1 = grain_128::ksb8(st);
+    const uint8_t yt1 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
     const auto splitted = split_bits(yt0, yt1);
@@ -269,24 +267,24 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
   // Decrypt cipher text and authenticate encrypted text bits
 
   for (size_t i = 0; i < ctlen; i++) {
-    const uint8_t yt0 = grain_128::ksb8(st);
+    const uint8_t yt0 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
-    const uint8_t yt1 = grain_128::ksb8(st);
+    const uint8_t yt1 = grain_128::ksb(st);
 
     {
-      const uint8_t s120 = grain_128::l8(st);
-      const uint8_t b120 = grain_128::f8(st);
+      const uint8_t s120 = grain_128::l(st);
+      const uint8_t b120 = grain_128::f(st);
 
-      grain_128::update_lfsr8(st, s120);
-      grain_128::update_nfsr8(st, b120);
+      grain_128::update_lfsr(st, s120);
+      grain_128::update_nfsr(st, b120);
     }
 
     const auto splitted = split_bits(yt0, yt1);
@@ -308,24 +306,24 @@ auth_padding_bit(grain_128::state_t* const st)
   // their presence doesn't hurt )
   constexpr uint8_t padding = 0b00000001;
 
-  const uint8_t yt0 = grain_128::ksb8(st);
+  const uint8_t yt0 = grain_128::ksb(st);
 
   {
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120);
-    grain_128::update_nfsr8(st, b120);
+    grain_128::update_lfsr(st, s120);
+    grain_128::update_nfsr(st, b120);
   }
 
-  const uint8_t yt1 = grain_128::ksb8(st);
+  const uint8_t yt1 = grain_128::ksb(st);
 
   {
-    const uint8_t s120 = grain_128::l8(st);
-    const uint8_t b120 = grain_128::f8(st);
+    const uint8_t s120 = grain_128::l(st);
+    const uint8_t b120 = grain_128::f(st);
 
-    grain_128::update_lfsr8(st, s120);
-    grain_128::update_nfsr8(st, b120);
+    grain_128::update_lfsr(st, s120);
+    grain_128::update_nfsr(st, b120);
   }
 
   const auto splitted = split_bits(yt0, yt1);

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -255,7 +255,7 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
   }
 }
 
-// Decrypts cipher text and authenticates decrypted text ( a bit at a time ),
+// Decrypts cipher text and authenticates decrypted text ( 8 bits at a time ),
 // following specification defined in section 2.3, 2.5 & 2.6.2 of Grain-128 AEAD
 //
 // Find document
@@ -268,37 +268,31 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
 {
   // Decrypt cipher text and authenticate encrypted text bits
 
-  const size_t ctblen = ctlen << 3;
-
-  for (size_t i = 0; i < ctblen; i++) {
-    const auto idx = grain_128::compute_index(i);
-    const uint8_t c_bit = grain_128::get_bit(enc, idx);
-
-    const uint8_t yt_e = grain_128::ksb(st); // even
+  for (size_t i = 0; i < ctlen; i++) {
+    const uint8_t yt0 = grain_128::ksb8(st);
 
     {
-      const uint8_t s127 = grain_128::l(st);
-      const uint8_t b127 = grain_128::f(st);
+      const uint8_t s120 = grain_128::l8(st);
+      const uint8_t b120 = grain_128::f8(st);
 
-      grain_128::update_lfsr(st, s127);
-      grain_128::update_nfsr(st, b127);
+      grain_128::update_lfsr8(st, s120);
+      grain_128::update_nfsr8(st, b120);
     }
 
-    const uint8_t t_bit = c_bit ^ yt_e;
-    grain_128::set_bit(txt, t_bit, idx);
-
-    const uint8_t yt_o = grain_128::ksb(st); // odd
+    const uint8_t yt1 = grain_128::ksb8(st);
 
     {
-      const uint8_t s127 = grain_128::l(st);
-      const uint8_t b127 = grain_128::f(st);
+      const uint8_t s120 = grain_128::l8(st);
+      const uint8_t b120 = grain_128::f8(st);
 
-      grain_128::update_lfsr(st, s127);
-      grain_128::update_nfsr(st, b127);
+      grain_128::update_lfsr8(st, s120);
+      grain_128::update_nfsr8(st, b120);
     }
 
-    grain_128::update_accumulator(st, t_bit);
-    grain_128::update_register(st, yt_o);
+    const auto splitted = split_bits(yt0, yt1);
+
+    txt[i] = enc[i] ^ splitted.first;                           // decrypt
+    grain_128::authenticated_byte(st, txt[i], splitted.second); // authenticate
   }
 }
 

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -533,6 +533,19 @@ from_le_bytes(const uint8_t* const bytes)
          (static_cast<uint64_t>(bytes[0]) << 0);
 }
 
+// Given a 64 -bit unsigned integer & a byte array of length 8, this routine
+// interprets u64 in little endian byte order and places each of 8 bytes in
+// designated byte indices.
+inline static void
+to_le_bytes(const uint64_t v, uint8_t* const bytes)
+{
+  for (size_t i = 0; i < 8; i++) {
+    const size_t boff = i << 3;
+
+    bytes[i] = static_cast<uint8_t>(v >> boff);
+  }
+}
+
 // Updates Grain-128 AEAD accumulator, authenticating 8 input message bits,
 // following definition provided in section 2.3 of Grain-128 AEAD specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -128,6 +128,45 @@ h(const state_t* const st)
   return hx;
 }
 
+// Boolean function `h(x)`, which takes 9 state variable bits ( for 8
+// consecutive cipher clocks ) & produces single bit ( for 8 consecutive cipher
+// clocks ), using formula
+//
+// h(x) = x0x1 + x2x3 + x4x5 + x6x7 + x0x4x8
+//
+// 2 of these input bits are from NFSR, while remaining 7 of them are from LFSR.
+//
+// Bits correspond to (x0, x1, ...x7, x8) -> (NFSR12, LFSR8, LFSR13, LFSR20,
+// NFSR95, LFSR42, LFSR60, LFSR79, LFSR94)
+//
+// See definition of `h(x)` function in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+//
+// Note, this function should do what `h(...)` does, but for 8 consecutive
+// rounds i.e. processing 8 bits per function invocation.
+inline static uint8_t
+h8(const state_t* const st)
+{
+  const uint8_t x0 = get_8bits(st->nfsr, 12);
+  const uint8_t x1 = get_8bits(st->lfsr, 8);
+  const uint8_t x2 = get_8bits(st->lfsr, 13);
+  const uint8_t x3 = get_8bits(st->lfsr, 20);
+  const uint8_t x4 = get_8bits(st->nfsr, 95);
+  const uint8_t x5 = get_8bits(st->lfsr, 42);
+  const uint8_t x6 = get_8bits(st->lfsr, 60);
+  const uint8_t x7 = get_8bits(st->lfsr, 79);
+  const uint8_t x8 = get_8bits(st->lfsr, 94);
+
+  const uint8_t x0x1 = x0 & x1;
+  const uint8_t x2x3 = x2 & x3;
+  const uint8_t x4x5 = x4 & x5;
+  const uint8_t x6x7 = x6 & x7;
+  const uint8_t x0x4x8 = x0 & x4 & x8;
+
+  const uint8_t hx = x0x1 ^ x2x3 ^ x4x5 ^ x6x7 ^ x0x4x8;
+  return hx;
+}
+
 // Pre-output generator function, producing single output (key stream) bit,
 // using formula
 //

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -335,6 +335,73 @@ f(const state_t* const st)
   return b127;
 }
 
+// s0 + F(Bt) --- update function of NFSR, computing 8 bits of NFSR ( starting
+// from bit index 120 ), for next eight cipher clock rounds
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static uint8_t
+f8(const state_t* const st)
+{
+  const uint8_t s0 = get_8bits(st->lfsr, 0);
+
+  const uint8_t b0 = get_8bits(st->nfsr, 0);
+  const uint8_t b26 = get_8bits(st->nfsr, 26);
+  const uint8_t b56 = get_8bits(st->nfsr, 56);
+  const uint8_t b91 = get_8bits(st->nfsr, 91);
+  const uint8_t b96 = get_8bits(st->nfsr, 96);
+
+  const uint8_t b3 = get_8bits(st->nfsr, 3);
+  const uint8_t b67 = get_8bits(st->nfsr, 67);
+
+  const uint8_t b11 = get_8bits(st->nfsr, 11);
+  const uint8_t b13 = get_8bits(st->nfsr, 13);
+
+  const uint8_t b17 = get_8bits(st->nfsr, 17);
+  const uint8_t b18 = get_8bits(st->nfsr, 18);
+
+  const uint8_t b27 = get_8bits(st->nfsr, 27);
+  const uint8_t b59 = get_8bits(st->nfsr, 59);
+
+  const uint8_t b40 = get_8bits(st->nfsr, 40);
+  const uint8_t b48 = get_8bits(st->nfsr, 48);
+
+  const uint8_t b61 = get_8bits(st->nfsr, 61);
+  const uint8_t b65 = get_8bits(st->nfsr, 65);
+
+  const uint8_t b68 = get_8bits(st->nfsr, 68);
+  const uint8_t b84 = get_8bits(st->nfsr, 84);
+
+  const uint8_t b22 = get_8bits(st->nfsr, 22);
+  const uint8_t b24 = get_8bits(st->nfsr, 24);
+  const uint8_t b25 = get_8bits(st->nfsr, 25);
+
+  const uint8_t b70 = get_8bits(st->nfsr, 70);
+  const uint8_t b78 = get_8bits(st->nfsr, 78);
+  const uint8_t b82 = get_8bits(st->nfsr, 82);
+
+  const uint8_t b88 = get_8bits(st->nfsr, 88);
+  const uint8_t b92 = get_8bits(st->nfsr, 92);
+  const uint8_t b93 = get_8bits(st->nfsr, 93);
+  const uint8_t b95 = get_8bits(st->nfsr, 95);
+
+  const uint8_t t0 = b0 ^ b26 ^ b56 ^ b91 ^ b96;
+  const uint8_t t1 = b3 & b67;
+  const uint8_t t2 = b11 & b13;
+  const uint8_t t3 = b17 & b18;
+  const uint8_t t4 = b27 & b59;
+  const uint8_t t5 = b40 & b48;
+  const uint8_t t6 = b61 & b65;
+  const uint8_t t7 = b68 & b84;
+  const uint8_t t8 = b22 & b24 & b25;
+  const uint8_t t9 = b70 & b78 & b82;
+  const uint8_t t10 = b88 & b92 & b93 & b95;
+
+  const uint8_t fbt = t0 ^ t1 ^ t2 ^ t3 ^ t4 ^ t5 ^ t6 ^ t7 ^ t8 ^ t9 ^ t10;
+  const uint8_t b120 = s0 ^ fbt;
+  return b120;
+}
+
 // Updates 128 -bit register by dropping bit 0 & setting new bit 127 ( which is
 // provided )
 //

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -60,76 +60,6 @@ get_8bits(const uint8_t* const arr, const size_t sidx)
   return bits;
 }
 
-// Given a byte array and an index pair in terms of a byte offset & a bit offset
-// ( inside the byte, which itself is selected using byte offset argument ),
-// this routine extracts out the bit and places it in least significant position
-// of a 8 -bit unsigned integer, which is returned back from this function.
-inline static constexpr uint8_t
-get_bit(const uint8_t* const arr, // byte array to extract the bit from
-        const std::pair<size_t, size_t> idx // byte and bit offset, in order
-)
-{
-  const uint8_t byte = arr[idx.first];
-  const uint8_t bit = byte >> idx.second;
-
-  return bit & 0b1;
-}
-
-// Given a byte array and an index pair in terms of a byte offset & a bit
-// offset, this routine sets the bit to the value provided by `bit` parameter (
-// value is placed in least significant bit position )
-inline static constexpr void
-set_bit(uint8_t* const arr,                 // byte array to set bit in
-        const uint8_t bit,                  // set bit to value in LSB
-        const std::pair<size_t, size_t> idx // byte and bit offset, in order
-)
-{
-  const uint8_t byte = arr[idx.first];
-
-  const uint8_t mask0 = 0xFF << (idx.second + 1);
-  const uint8_t mask1 = 0xFF >> (8 - idx.second);
-
-  const uint8_t msb = byte & mask0;
-  const uint8_t lsb = byte & mask1;
-
-  arr[idx.first] = msb | (bit << idx.second) | lsb;
-}
-
-// Boolean function `h(x)`, which takes 9 state variable bits & produces single
-// bit, using formula
-//
-// h(x) = x0x1 + x2x3 + x4x5 + x6x7 + x0x4x8
-//
-// 2 of these input bits are from NFSR, while remaining 7 of them are from LFSR.
-//
-// Bits correspond to (x0, x1, ...x7, x8) -> (NFSR12, LFSR8, LFSR13, LFSR20,
-// NFSR95, LFSR42, LFSR60, LFSR79, LFSR94)
-//
-// See definition of `h(x)` function in page 7 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static uint8_t
-h(const state_t* const st)
-{
-  const uint8_t x0 = get_bit(st->nfsr, compute_index(12));
-  const uint8_t x1 = get_bit(st->lfsr, compute_index(8));
-  const uint8_t x2 = get_bit(st->lfsr, compute_index(13));
-  const uint8_t x3 = get_bit(st->lfsr, compute_index(20));
-  const uint8_t x4 = get_bit(st->nfsr, compute_index(95));
-  const uint8_t x5 = get_bit(st->lfsr, compute_index(42));
-  const uint8_t x6 = get_bit(st->lfsr, compute_index(60));
-  const uint8_t x7 = get_bit(st->lfsr, compute_index(79));
-  const uint8_t x8 = get_bit(st->lfsr, compute_index(94));
-
-  const uint8_t x0x1 = x0 & x1;
-  const uint8_t x2x3 = x2 & x3;
-  const uint8_t x4x5 = x4 & x5;
-  const uint8_t x6x7 = x6 & x7;
-  const uint8_t x0x4x8 = x0 & x4 & x8;
-
-  const uint8_t hx = x0x1 ^ x2x3 ^ x4x5 ^ x6x7 ^ x0x4x8;
-  return hx;
-}
-
 // Boolean function `h(x)`, which takes 9 state variable bits ( for 8
 // consecutive cipher clocks ) & produces single bit ( for 8 consecutive cipher
 // clocks ), using formula
@@ -147,7 +77,7 @@ h(const state_t* const st)
 // Note, this function should do what `h(...)` does, but for 8 consecutive
 // rounds i.e. processing 8 bits per function invocation.
 inline static uint8_t
-h8(const state_t* const st)
+h(const state_t* const st)
 {
   const uint8_t x0 = get_8bits(st->nfsr, 12);
   const uint8_t x1 = get_8bits(st->lfsr, 8);
@@ -169,36 +99,6 @@ h8(const state_t* const st)
   return hx;
 }
 
-// Pre-output generator function, producing single output (key stream) bit,
-// using formula
-//
-// yt = h(x) + st93 + ∑ j∈A (btj)
-//
-// A = {2, 15, 36, 45, 64, 73, 89}
-//
-// See definition in page 7 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static uint8_t
-ksb(const state_t* const st)
-{
-  const uint8_t hx = h(st);
-
-  const uint8_t s93 = get_bit(st->lfsr, compute_index(93));
-
-  const uint8_t b2 = get_bit(st->nfsr, compute_index(2));
-  const uint8_t b15 = get_bit(st->nfsr, compute_index(15));
-  const uint8_t b36 = get_bit(st->nfsr, compute_index(36));
-  const uint8_t b45 = get_bit(st->nfsr, compute_index(45));
-  const uint8_t b64 = get_bit(st->nfsr, compute_index(64));
-  const uint8_t b73 = get_bit(st->nfsr, compute_index(73));
-  const uint8_t b89 = get_bit(st->nfsr, compute_index(89));
-
-  const uint8_t bt = b2 ^ b15 ^ b36 ^ b45 ^ b64 ^ b73 ^ b89;
-
-  const uint8_t yt = hx ^ s93 ^ bt;
-  return yt;
-}
-
 // Pre-output generator function, producing eight output (key stream) bits,
 // using formula
 //
@@ -212,9 +112,9 @@ ksb(const state_t* const st)
 // Note, this function should do what `ksb(...)` does, but for 8 consecutive
 // rounds i.e. producing 8 key stream bits per function invocation.
 inline static uint8_t
-ksb8(const state_t* const st)
+ksb(const state_t* const st)
 {
-  const uint8_t hx = h8(st);
+  const uint8_t hx = h(st);
 
   const uint8_t s93 = get_8bits(st->lfsr, 93);
 
@@ -232,32 +132,13 @@ ksb8(const state_t* const st)
   return yt;
 }
 
-// L(St) --- update function of LFSR, computing 127 -th bit of LFSR, for next
-// round
-//
-// See definition in page 7 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static uint8_t
-l(const state_t* const st)
-{
-  const uint8_t s0 = get_bit(st->lfsr, compute_index(0));
-  const uint8_t s7 = get_bit(st->lfsr, compute_index(7));
-  const uint8_t s38 = get_bit(st->lfsr, compute_index(38));
-  const uint8_t s70 = get_bit(st->lfsr, compute_index(70));
-  const uint8_t s81 = get_bit(st->lfsr, compute_index(81));
-  const uint8_t s96 = get_bit(st->lfsr, compute_index(96));
-
-  const uint8_t s127 = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
-  return s127;
-}
-
 // L(St) --- update function of LFSR, computing 8 bits of LFSR ( starting from
 // bit index 120 ), for next eight cipher clock rounds
 //
 // See definition in page 7 of Grain-128 AEAD specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
 inline static uint8_t
-l8(const state_t* const st)
+l(const state_t* const st)
 {
   const uint8_t s0 = get_8bits(st->lfsr, 0);
   const uint8_t s7 = get_8bits(st->lfsr, 7);
@@ -270,80 +151,13 @@ l8(const state_t* const st)
   return s120;
 }
 
-// s0 + F(Bt) --- update function of NFSR, computing 127 -th bit of NFSR, for
-// next round
-//
-// See definition in page 7 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static uint8_t
-f(const state_t* const st)
-{
-  const uint8_t s0 = get_bit(st->lfsr, compute_index(0));
-
-  const uint8_t b0 = get_bit(st->nfsr, compute_index(0));
-  const uint8_t b26 = get_bit(st->nfsr, compute_index(26));
-  const uint8_t b56 = get_bit(st->nfsr, compute_index(56));
-  const uint8_t b91 = get_bit(st->nfsr, compute_index(91));
-  const uint8_t b96 = get_bit(st->nfsr, compute_index(96));
-
-  const uint8_t b3 = get_bit(st->nfsr, compute_index(3));
-  const uint8_t b67 = get_bit(st->nfsr, compute_index(67));
-
-  const uint8_t b11 = get_bit(st->nfsr, compute_index(11));
-  const uint8_t b13 = get_bit(st->nfsr, compute_index(13));
-
-  const uint8_t b17 = get_bit(st->nfsr, compute_index(17));
-  const uint8_t b18 = get_bit(st->nfsr, compute_index(18));
-
-  const uint8_t b27 = get_bit(st->nfsr, compute_index(27));
-  const uint8_t b59 = get_bit(st->nfsr, compute_index(59));
-
-  const uint8_t b40 = get_bit(st->nfsr, compute_index(40));
-  const uint8_t b48 = get_bit(st->nfsr, compute_index(48));
-
-  const uint8_t b61 = get_bit(st->nfsr, compute_index(61));
-  const uint8_t b65 = get_bit(st->nfsr, compute_index(65));
-
-  const uint8_t b68 = get_bit(st->nfsr, compute_index(68));
-  const uint8_t b84 = get_bit(st->nfsr, compute_index(84));
-
-  const uint8_t b22 = get_bit(st->nfsr, compute_index(22));
-  const uint8_t b24 = get_bit(st->nfsr, compute_index(24));
-  const uint8_t b25 = get_bit(st->nfsr, compute_index(25));
-
-  const uint8_t b70 = get_bit(st->nfsr, compute_index(70));
-  const uint8_t b78 = get_bit(st->nfsr, compute_index(78));
-  const uint8_t b82 = get_bit(st->nfsr, compute_index(82));
-
-  const uint8_t b88 = get_bit(st->nfsr, compute_index(88));
-  const uint8_t b92 = get_bit(st->nfsr, compute_index(92));
-  const uint8_t b93 = get_bit(st->nfsr, compute_index(93));
-  const uint8_t b95 = get_bit(st->nfsr, compute_index(95));
-
-  const uint8_t t0 = b0 ^ b26 ^ b56 ^ b91 ^ b96;
-  const uint8_t t1 = b3 & b67;
-  const uint8_t t2 = b11 & b13;
-  const uint8_t t3 = b17 & b18;
-  const uint8_t t4 = b27 & b59;
-  const uint8_t t5 = b40 & b48;
-  const uint8_t t6 = b61 & b65;
-  const uint8_t t7 = b68 & b84;
-  const uint8_t t8 = b22 & b24 & b25;
-  const uint8_t t9 = b70 & b78 & b82;
-  const uint8_t t10 = b88 & b92 & b93 & b95;
-
-  const uint8_t fbt = t0 ^ t1 ^ t2 ^ t3 ^ t4 ^ t5 ^ t6 ^ t7 ^ t8 ^ t9 ^ t10;
-  const uint8_t b127 = s0 ^ fbt;
-  return b127;
-}
-
 // s0 + F(Bt) --- update function of NFSR, computing 8 bits of NFSR ( starting
 // from bit index 120 ), for next eight cipher clock rounds
 //
 // See definition in page 7 of Grain-128 AEAD specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
 inline static uint8_t
-f8(const state_t* const st)
+f(const state_t* const st)
 {
   const uint8_t s0 = get_8bits(st->lfsr, 0);
 
@@ -404,57 +218,14 @@ f8(const state_t* const st)
   return b120;
 }
 
-// Updates 128 -bit register by dropping bit 0 & setting new bit 127 ( which is
-// provided )
-//
-// This generic function can be used for updating both 128 -bit LFSR and NFSR
-inline static void
-update(uint8_t* const reg,  // 128 -bit register to be updated
-       const uint8_t bit127 // set bit 127 to this value
-)
-{
-  const uint8_t s119 = get_bit(reg, compute_index(120));
-  const uint8_t s111 = get_bit(reg, compute_index(112));
-  const uint8_t s103 = get_bit(reg, compute_index(104));
-  const uint8_t s95 = get_bit(reg, compute_index(96));
-  const uint8_t s87 = get_bit(reg, compute_index(88));
-  const uint8_t s79 = get_bit(reg, compute_index(80));
-  const uint8_t s71 = get_bit(reg, compute_index(72));
-  const uint8_t s63 = get_bit(reg, compute_index(64));
-  const uint8_t s55 = get_bit(reg, compute_index(56));
-  const uint8_t s47 = get_bit(reg, compute_index(48));
-  const uint8_t s39 = get_bit(reg, compute_index(40));
-  const uint8_t s31 = get_bit(reg, compute_index(32));
-  const uint8_t s23 = get_bit(reg, compute_index(24));
-  const uint8_t s15 = get_bit(reg, compute_index(16));
-  const uint8_t s7 = get_bit(reg, compute_index(8));
-
-  reg[15] = (bit127 << 7) | (reg[15] >> 1);
-  reg[14] = (s119 << 7) | (reg[14] >> 1);
-  reg[13] = (s111 << 7) | (reg[13] >> 1);
-  reg[12] = (s103 << 7) | (reg[12] >> 1);
-  reg[11] = (s95 << 7) | (reg[11] >> 1);
-  reg[10] = (s87 << 7) | (reg[10] >> 1);
-  reg[9] = (s79 << 7) | (reg[9] >> 1);
-  reg[8] = (s71 << 7) | (reg[8] >> 1);
-  reg[7] = (s63 << 7) | (reg[7] >> 1);
-  reg[6] = (s55 << 7) | (reg[6] >> 1);
-  reg[5] = (s47 << 7) | (reg[5] >> 1);
-  reg[4] = (s39 << 7) | (reg[4] >> 1);
-  reg[3] = (s31 << 7) | (reg[3] >> 1);
-  reg[2] = (s23 << 7) | (reg[2] >> 1);
-  reg[1] = (s15 << 7) | (reg[1] >> 1);
-  reg[0] = (s7 << 7) | (reg[0] >> 1);
-}
-
 // Updates 128 -bit register by dropping bit [0..8) & setting new bit [120..128)
 // ( which is provided by parameter `bit120` ), while shifting other bits
 // leftwards ( i.e. MSB moving towards LSB ) | bit0 -> LSB and bit127 -> MSB
 //
 // This generic function can be used for updating both 128 -bit LFSR and NFSR
 inline static void
-update8(uint8_t* const reg,  // 128 -bit register to be updated
-        const uint8_t bit120 // set bit [120..128) to this value
+update(uint8_t* const reg,  // 128 -bit register to be updated
+       const uint8_t bit120 // set bit [120..128) to this value
 )
 {
   for (size_t i = 0; i < 15; i++) {
@@ -464,34 +235,14 @@ update8(uint8_t* const reg,  // 128 -bit register to be updated
   reg[15] = bit120;
 }
 
-// Updates LFSR, by shifting 128 -bit register by 1 -bit leftwards ( when least
-// significant bit lives on left side of the bit array i.e. bit 0 is dropped &
-// new bit 127 is placed ), while placing `s127` as 127 -th bit of LFSR for next
-// round
-inline static void
-update_lfsr(state_t* const st, const uint8_t s127)
-{
-  update(st->lfsr, s127);
-}
-
 // Updates LFSR, by shifting 128 -bit register by 8 -bits leftwards ( when least
 // significant bit lives on left side of the bit array i.e. bits [0..8) are
 // dropped & new bits [120..128) are placed ), while placing `s120` as
 // [120..128) -th bits of LFSR for next iteration
 inline static void
-update_lfsr8(state_t* const st, const uint8_t s120)
+update_lfsr(state_t* const st, const uint8_t s120)
 {
-  update8(st->lfsr, s120);
-}
-
-// Updates NFSR, by shifting 128 -bit register by 1 -bit leftwards ( when least
-// significant bit lives on left side of the bit array i.e. bit 0 is dropped &
-// new bit 127 is placed ), while placing `b127` as 127 -th bit of NFSR for next
-// round
-inline static void
-update_nfsr(state_t* const st, const uint8_t b127)
-{
-  update(st->nfsr, b127);
+  update(st->lfsr, s120);
 }
 
 // Updates NFSR, by shifting 128 -bit register by 8 -bits leftwards ( when least
@@ -499,25 +250,9 @@ update_nfsr(state_t* const st, const uint8_t b127)
 // dropped & new bits [120..128) are placed ), while placing `b120` as
 // [120..128) -th bits of NFSR for next iteration
 inline static void
-update_nfsr8(state_t* const st, const uint8_t b120)
+update_nfsr(state_t* const st, const uint8_t b120)
 {
-  update8(st->nfsr, b120);
-}
-
-// Updates Grain-128 AEAD accumulator, authenticating single input message bit,
-// following definition provided in section 2.3 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static void
-update_accumulator(state_t* const st, // Grain-128 AEAD state
-                   const uint8_t msg  // single bit message, living in LSB
-)
-{
-  constexpr uint8_t br[2]{ 0b00000000, 0b11111111 };
-  const uint8_t widened = br[msg];
-
-  for (size_t i = 0; i < 8; i++) {
-    st->acc[i] ^= st->sreg[i] & widened;
-  }
+  update(st->nfsr, b120);
 }
 
 // Given a byte array of length 8, this routine interprets those bytes in little
@@ -631,34 +366,6 @@ authenticated_byte(
     to_le_bytes(acc8, st->acc);
     to_le_bytes(sreg8, st->sreg);
   }
-}
-
-// Updates shift register using authentication bit ( every odd bit produced by
-// pre-output generator )
-//
-// See definition in section 2.3 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static void
-update_register(state_t* const st, // Grain-128 AEAD state
-                const uint8_t auth // single authentication bit
-)
-{
-  const uint8_t s55 = get_bit(st->sreg, compute_index(56));
-  const uint8_t s47 = get_bit(st->sreg, compute_index(48));
-  const uint8_t s39 = get_bit(st->sreg, compute_index(40));
-  const uint8_t s31 = get_bit(st->sreg, compute_index(32));
-  const uint8_t s23 = get_bit(st->sreg, compute_index(24));
-  const uint8_t s15 = get_bit(st->sreg, compute_index(16));
-  const uint8_t s7 = get_bit(st->sreg, compute_index(8));
-
-  st->sreg[7] = (auth << 7) | (st->sreg[7] >> 1);
-  st->sreg[6] = (s55 << 7) | (st->sreg[6] >> 1);
-  st->sreg[5] = (s47 << 7) | (st->sreg[5] >> 1);
-  st->sreg[4] = (s39 << 7) | (st->sreg[4] >> 1);
-  st->sreg[3] = (s31 << 7) | (st->sreg[3] >> 1);
-  st->sreg[2] = (s23 << 7) | (st->sreg[2] >> 1);
-  st->sreg[1] = (s15 << 7) | (st->sreg[1] >> 1);
-  st->sreg[0] = (s7 << 7) | (st->sreg[0] >> 1);
 }
 
 }

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -249,6 +249,25 @@ l(const state_t* const st)
   return s127;
 }
 
+// L(St) --- update function of LFSR, computing 8 bits of LFSR ( starting from
+// bit index 120 ), for next eight cipher clock rounds
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static uint8_t
+l8(const state_t* const st)
+{
+  const uint8_t s0 = get_8bits(st->lfsr, 0);
+  const uint8_t s7 = get_8bits(st->lfsr, 7);
+  const uint8_t s38 = get_8bits(st->lfsr, 38);
+  const uint8_t s70 = get_8bits(st->lfsr, 70);
+  const uint8_t s81 = get_8bits(st->lfsr, 81);
+  const uint8_t s96 = get_8bits(st->lfsr, 96);
+
+  const uint8_t s120 = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
+  return s120;
+}
+
 // s0 + F(Bt) --- update function of NFSR, computing 127 -th bit of NFSR, for
 // next round
 //

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -445,6 +445,23 @@ update(uint8_t* const reg,  // 128 -bit register to be updated
   reg[0] = (s7 << 7) | (reg[0] >> 1);
 }
 
+// Updates 128 -bit register by dropping bit [0..8) & setting new bit [120..128)
+// ( which is provided by parameter `bit120` ), while shifting other bits
+// leftwards ( i.e. MSB moving towards LSB ) | bit0 -> LSB and bit127 -> MSB
+//
+// This generic function can be used for updating both 128 -bit LFSR and NFSR
+inline static void
+update8(uint8_t* const reg,  // 128 -bit register to be updated
+        const uint8_t bit120 // set bit [120..128) to this value
+)
+{
+  for (size_t i = 0; i < 15; i++) {
+    reg[i] = reg[i + 1];
+  }
+
+  reg[15] = bit120;
+}
+
 // Updates LFSR, by shifting 128 -bit register by 1 -bit leftwards ( when least
 // significant bit lives on left side of the bit array i.e. bit 0 is dropped &
 // new bit 127 is placed ), while placing `s127` as 127 -th bit of LFSR for next
@@ -455,6 +472,16 @@ update_lfsr(state_t* const st, const uint8_t s127)
   update(st->lfsr, s127);
 }
 
+// Updates LFSR, by shifting 128 -bit register by 8 -bits leftwards ( when least
+// significant bit lives on left side of the bit array i.e. bits [0..8) are
+// dropped & new bits [120..128) are placed ), while placing `s120` as
+// [120..128) -th bits of LFSR for next iteration
+inline static void
+update_lfsr8(state_t* const st, const uint8_t s120)
+{
+  update8(st->lfsr, s120);
+}
+
 // Updates NFSR, by shifting 128 -bit register by 1 -bit leftwards ( when least
 // significant bit lives on left side of the bit array i.e. bit 0 is dropped &
 // new bit 127 is placed ), while placing `b127` as 127 -th bit of NFSR for next
@@ -463,6 +490,16 @@ inline static void
 update_nfsr(state_t* const st, const uint8_t b127)
 {
   update(st->nfsr, b127);
+}
+
+// Updates NFSR, by shifting 128 -bit register by 8 -bits leftwards ( when least
+// significant bit lives on left side of the bit array i.e. bits [0..8) are
+// dropped & new bits [120..128) are placed ), while placing `b120` as
+// [120..128) -th bits of NFSR for next iteration
+inline static void
+update_nfsr8(state_t* const st, const uint8_t b120)
+{
+  update8(st->nfsr, b120);
 }
 
 // Updates Grain-128 AEAD accumulator, authenticating single input message bit,

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -197,6 +197,39 @@ ksb(const state_t* const st)
   return yt;
 }
 
+// Pre-output generator function, producing eight output (key stream) bits,
+// using formula
+//
+// yt = h(x) + st93 + ∑ j∈A (btj)
+//
+// A = {2, 15, 36, 45, 64, 73, 89}
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+//
+// Note, this function should do what `ksb(...)` does, but for 8 consecutive
+// rounds i.e. producing 8 key stream bits per function invocation.
+inline static uint8_t
+ksb8(const state_t* const st)
+{
+  const uint8_t hx = h8(st);
+
+  const uint8_t s93 = get_8bits(st->lfsr, 93);
+
+  const uint8_t b2 = get_8bits(st->nfsr, 2);
+  const uint8_t b15 = get_8bits(st->nfsr, 15);
+  const uint8_t b36 = get_8bits(st->nfsr, 36);
+  const uint8_t b45 = get_8bits(st->nfsr, 45);
+  const uint8_t b64 = get_8bits(st->nfsr, 64);
+  const uint8_t b73 = get_8bits(st->nfsr, 73);
+  const uint8_t b89 = get_8bits(st->nfsr, 89);
+
+  const uint8_t bt = b2 ^ b15 ^ b36 ^ b45 ^ b64 ^ b73 ^ b89;
+
+  const uint8_t yt = hx ^ s93 ^ bt;
+  return yt;
+}
+
 // L(St) --- update function of LFSR, computing 127 -th bit of LFSR, for next
 // round
 //

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -518,6 +518,21 @@ update_accumulator(state_t* const st, // Grain-128 AEAD state
   }
 }
 
+// Given a byte array of length 8, this routine interprets those bytes in little
+// endian byte order, computing a 64 -bit unsigned integer
+inline static uint64_t
+from_le_bytes(const uint8_t* const bytes)
+{
+  return (static_cast<uint64_t>(bytes[7]) << 56) |
+         (static_cast<uint64_t>(bytes[6]) << 48) |
+         (static_cast<uint64_t>(bytes[5]) << 40) |
+         (static_cast<uint64_t>(bytes[4]) << 32) |
+         (static_cast<uint64_t>(bytes[3]) << 24) |
+         (static_cast<uint64_t>(bytes[2]) << 16) |
+         (static_cast<uint64_t>(bytes[1]) << 8) |
+         (static_cast<uint64_t>(bytes[0]) << 0);
+}
+
 // Updates Grain-128 AEAD accumulator, authenticating 8 input message bits,
 // following definition provided in section 2.3 of Grain-128 AEAD specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -518,6 +518,20 @@ update_accumulator(state_t* const st, // Grain-128 AEAD state
   }
 }
 
+// Updates Grain-128 AEAD accumulator, authenticating 8 input message bits,
+// following definition provided in section 2.3 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static void
+update_accumulator8(
+  state_t* const st, // Grain-128 AEAD state
+  const uint8_t msg  // 8 -bit wide message ( being authenticated )
+)
+{
+  for (size_t i = 0; i < 8; i++) {
+    st->acc[i] ^= st->sreg[i] & msg;
+  }
+}
+
 // Updates shift register using authentication bit ( every odd bit produced by
 // pre-output generator )
 //
@@ -544,6 +558,23 @@ update_register(state_t* const st, // Grain-128 AEAD state
   st->sreg[2] = (s23 << 7) | (st->sreg[2] >> 1);
   st->sreg[1] = (s15 << 7) | (st->sreg[1] >> 1);
   st->sreg[0] = (s7 << 7) | (st->sreg[0] >> 1);
+}
+
+// Updates shift register using authentication 8 bits ( eight consecutive odd
+// bits produced by pre-output generator )
+//
+// See definition in section 2.3 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static void
+update_register8(state_t* const st, // Grain-128 AEAD state
+                 const uint8_t auth // 8 authentication bits
+)
+{
+  for (size_t i = 0; i < 7; i++) {
+    st->sreg[i] = st->sreg[i + 1];
+  }
+
+  st->sreg[7] = auth;
 }
 
 }

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -421,8 +421,8 @@ update(uint8_t* const reg,  // 128 -bit register to be updated
 // This generic function can be used for updating both 128 -bit LFSR and NFSR,
 // when executing 32 consecutive rounds of cipher clocks, in parallel
 inline static void
-update(uint8_t* const reg,  // 128 -bit register to be updated
-       const uint32_t bit96 // set bit [96..128) to this value
+updatex32(uint8_t* const reg,  // 128 -bit register to be updated
+          const uint32_t bit96 // set bit [96..128) to this value
 )
 {
   for (size_t i = 0; i < 12; i++) {
@@ -456,9 +456,9 @@ update_lfsr(state_t* const st, const uint8_t s120)
 // Use this routine, when executing 32 consecutive stream cipher clocks, in
 // parallel
 inline static void
-update_lfsr(state_t* const st, const uint32_t s96)
+update_lfsrx32(state_t* const st, const uint32_t s96)
 {
-  update(st->lfsr, s96);
+  updatex32(st->lfsr, s96);
 }
 
 // Updates NFSR, by shifting 128 -bit register by 8 -bits leftwards ( when least
@@ -482,9 +482,9 @@ update_nfsr(state_t* const st, const uint8_t b120)
 // Use this routine, when executing 32 consecutive stream cipher clocks, in
 // parallel
 inline static void
-update_nfsr(state_t* const st, const uint32_t b96)
+update_nfsrx32(state_t* const st, const uint32_t b96)
 {
-  update(st->nfsr, b96);
+  updatex32(st->nfsr, b96);
 }
 
 // Given a byte array of length 8, this routine interprets those bytes in little

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -546,18 +546,77 @@ to_le_bytes(const uint64_t v, uint8_t* const bytes)
   }
 }
 
-// Updates Grain-128 AEAD accumulator, authenticating 8 input message bits,
-// following definition provided in section 2.3 of Grain-128 AEAD specification
+// Updates Grain-128 AEAD accumulator & shift register, authenticating 8 input
+// message bits ( consuming into accumulator ), while also using eight
+// authentication bits ( eight consecutive odd bits produced by pre-output
+// generator i.e. `ksb` ) following definition provided in section 2.3 of
+// Grain-128 AEAD specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
 inline static void
-update_accumulator8(
-  state_t* const st, // Grain-128 AEAD state
-  const uint8_t msg  // 8 -bit wide message ( being authenticated )
+authenticated_byte(
+  state_t* const st, // Grain-128 AEAD cipher state
+  const uint8_t msg, // eight input message bits ( to be authenticated )
+  const uint8_t ksb  // eight odd pre-output generator bits ( auth bits )
 )
 {
-  for (size_t i = 0; i < 8; i++) {
-    st->acc[i] ^= st->sreg[i] & msg;
-  }
+  constexpr uint64_t br[]{
+    0b0000000000000000000000000000000000000000000000000000000000000000ul,
+    0b1111111111111111111111111111111111111111111111111111111111111111ul
+  };
+
+  const uint64_t acc0 = from_le_bytes(st->acc);
+  const uint64_t sreg0 = from_le_bytes(st->sreg);
+
+  const uint8_t m0 = (msg >> 0) & 0b1;
+  const uint8_t k0 = (ksb >> 0) & 0b1;
+
+  const uint64_t acc1 = acc0 ^ (br[m0] & sreg0);
+  const uint64_t sreg1 = (sreg0 >> 1) | (static_cast<uint64_t>(k0) << 63);
+
+  const uint8_t m1 = (msg >> 1) & 0b1;
+  const uint8_t k1 = (ksb >> 1) & 0b1;
+
+  const uint64_t acc2 = acc1 ^ (br[m1] & sreg1);
+  const uint64_t sreg2 = (sreg1 >> 1) | (static_cast<uint64_t>(k1) << 63);
+
+  const uint8_t m2 = (msg >> 2) & 0b1;
+  const uint8_t k2 = (ksb >> 2) & 0b1;
+
+  const uint64_t acc3 = acc2 ^ (br[m2] & sreg2);
+  const uint64_t sreg3 = (sreg2 >> 1) | (static_cast<uint64_t>(k2) << 63);
+
+  const uint8_t m3 = (msg >> 3) & 0b1;
+  const uint8_t k3 = (ksb >> 3) & 0b1;
+
+  const uint64_t acc4 = acc3 ^ (br[m3] & sreg3);
+  const uint64_t sreg4 = (sreg3 >> 1) | (static_cast<uint64_t>(k3) << 63);
+
+  const uint8_t m4 = (msg >> 4) & 0b1;
+  const uint8_t k4 = (ksb >> 4) & 0b1;
+
+  const uint64_t acc5 = acc4 ^ (br[m4] & sreg4);
+  const uint64_t sreg5 = (sreg4 >> 1) | (static_cast<uint64_t>(k4) << 63);
+
+  const uint8_t m5 = (msg >> 5) & 0b1;
+  const uint8_t k5 = (ksb >> 5) & 0b1;
+
+  const uint64_t acc6 = acc5 ^ (br[m5] & sreg5);
+  const uint64_t sreg6 = (sreg5 >> 1) | (static_cast<uint64_t>(k5) << 63);
+
+  const uint8_t m6 = (msg >> 6) & 0b1;
+  const uint8_t k6 = (ksb >> 6) & 0b1;
+
+  const uint64_t acc7 = acc6 ^ (br[m6] & sreg6);
+  const uint64_t sreg7 = (sreg6 >> 1) | (static_cast<uint64_t>(k6) << 63);
+
+  const uint8_t m7 = (msg >> 7) & 0b1;
+  const uint8_t k7 = (ksb >> 7) & 0b1;
+
+  const uint64_t acc8 = acc7 ^ (br[m7] & sreg7);
+  const uint64_t sreg8 = (sreg7 >> 1) | (static_cast<uint64_t>(k7) << 63);
+
+  to_le_bytes(acc8, st->acc);
+  to_le_bytes(sreg8, st->sreg);
 }
 
 // Updates shift register using authentication bit ( every odd bit produced by
@@ -586,23 +645,6 @@ update_register(state_t* const st, // Grain-128 AEAD state
   st->sreg[2] = (s23 << 7) | (st->sreg[2] >> 1);
   st->sreg[1] = (s15 << 7) | (st->sreg[1] >> 1);
   st->sreg[0] = (s7 << 7) | (st->sreg[0] >> 1);
-}
-
-// Updates shift register using authentication 8 bits ( eight consecutive odd
-// bits produced by pre-output generator )
-//
-// See definition in section 2.3 of Grain-128 AEAD specification
-// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
-inline static void
-update_register8(state_t* const st, // Grain-128 AEAD state
-                 const uint8_t auth // 8 authentication bits
-)
-{
-  for (size_t i = 0; i < 7; i++) {
-    st->sreg[i] = st->sreg[i + 1];
-  }
-
-  st->sreg[7] = auth;
 }
 
 }

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -60,6 +60,38 @@ get_8bits(const uint8_t* const arr, const size_t sidx)
   return bits;
 }
 
+// Given a byte array and a starting bit index ( in that byte array ), this
+// routine extracts out 32 consecutive bits ( all indexing starts from 0 )
+// starting from provided bit index | end index is calculated as (sidx + 31)
+inline static constexpr uint32_t
+get_32bits(const uint8_t* const arr, const size_t sidx)
+{
+  const size_t eidx = sidx + 31ul;
+
+  const auto sidx_ = compute_index(sidx);
+  const auto eidx_ = compute_index(eidx);
+
+  const uint8_t lo = arr[sidx_.first] >> sidx_.second;
+  const uint8_t hi = arr[eidx_.first] << (7ul - eidx_.second);
+
+  const size_t mid_bytes = eidx_.first - sidx_.first + 1ul;
+
+  const uint32_t lsb = static_cast<uint32_t>(lo);
+  const uint32_t msb = static_cast<uint32_t>(hi) << (mid_bytes << 3);
+
+  uint32_t mid = 0u;
+
+  for (size_t i = 0; i < mid_bytes; i++) {
+    const size_t off = sidx_.first + 1ul;
+    const size_t boff = i << 3;
+
+    mid |= static_cast<uint32_t>(arr[off + i]) << boff;
+  }
+
+  const uint32_t res = msb | (mid << (8ul - sidx_.second)) | lsb;
+  return res;
+}
+
 // Boolean function `h(x)`, which takes 9 state variable bits ( for 8
 // consecutive cipher clocks ) & produces single bit ( for 8 consecutive cipher
 // clocks ), using formula

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -194,6 +194,36 @@ ksb(const state_t* const st)
   return yt;
 }
 
+// Pre-output generator function, producing 32 output (key stream) bits ( i.e.
+// invoking 32 consecutive rounds in parallel ), using formula
+//
+// yt = h(x) + st93 + ∑ j∈A (btj)
+//
+// A = {2, 15, 36, 45, 64, 73, 89}
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static uint32_t
+ksbx32(const state_t* const st)
+{
+  const uint32_t hx = hx32(st);
+
+  const uint32_t s93 = get_32bits(st->lfsr, 93);
+
+  const uint32_t b2 = get_32bits(st->nfsr, 2);
+  const uint32_t b15 = get_32bits(st->nfsr, 15);
+  const uint32_t b36 = get_32bits(st->nfsr, 36);
+  const uint32_t b45 = get_32bits(st->nfsr, 45);
+  const uint32_t b64 = get_32bits(st->nfsr, 64);
+  const uint32_t b73 = get_32bits(st->nfsr, 73);
+  const uint32_t b89 = get_32bits(st->nfsr, 89);
+
+  const uint32_t bt = b2 ^ b15 ^ b36 ^ b45 ^ b64 ^ b73 ^ b89;
+
+  const uint32_t yt = hx ^ s93 ^ bt;
+  return yt;
+}
+
 // L(St) --- update function of LFSR, computing 8 bits of LFSR ( starting from
 // bit index 120 ), for next eight cipher clock rounds
 //

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -239,8 +239,8 @@ l(const state_t* const st)
   const uint8_t s81 = get_8bits(st->lfsr, 81);
   const uint8_t s96 = get_8bits(st->lfsr, 96);
 
-  const uint8_t s120 = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
-  return s120;
+  const uint8_t res = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
+  return res;
 }
 
 // L(St) --- update function of LFSR, computing 32 bits of LFSR ( starting from
@@ -258,8 +258,8 @@ lx32(const state_t* const st)
   const uint32_t s81 = get_32bits(st->lfsr, 81);
   const uint32_t s96 = get_32bits(st->lfsr, 96);
 
-  const uint32_t s120 = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
-  return s120;
+  const uint32_t res = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
+  return res;
 }
 
 // s0 + F(Bt) --- update function of NFSR, computing 8 bits of NFSR ( starting
@@ -325,8 +325,75 @@ f(const state_t* const st)
   const uint8_t t10 = b88 & b92 & b93 & b95;
 
   const uint8_t fbt = t0 ^ t1 ^ t2 ^ t3 ^ t4 ^ t5 ^ t6 ^ t7 ^ t8 ^ t9 ^ t10;
-  const uint8_t b120 = s0 ^ fbt;
-  return b120;
+  const uint8_t res = s0 ^ fbt;
+  return res;
+}
+
+// s0 + F(Bt) --- update function of NFSR, computing 32 bits of NFSR ( starting
+// from bit index 96 ), for next 32 cipher clock rounds, in parallel
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static uint32_t
+fx32(const state_t* const st)
+{
+  const uint32_t s0 = get_32bits(st->lfsr, 0);
+
+  const uint32_t b0 = get_32bits(st->nfsr, 0);
+  const uint32_t b26 = get_32bits(st->nfsr, 26);
+  const uint32_t b56 = get_32bits(st->nfsr, 56);
+  const uint32_t b91 = get_32bits(st->nfsr, 91);
+  const uint32_t b96 = get_32bits(st->nfsr, 96);
+
+  const uint32_t b3 = get_32bits(st->nfsr, 3);
+  const uint32_t b67 = get_32bits(st->nfsr, 67);
+
+  const uint32_t b11 = get_32bits(st->nfsr, 11);
+  const uint32_t b13 = get_32bits(st->nfsr, 13);
+
+  const uint32_t b17 = get_32bits(st->nfsr, 17);
+  const uint32_t b18 = get_32bits(st->nfsr, 18);
+
+  const uint32_t b27 = get_32bits(st->nfsr, 27);
+  const uint32_t b59 = get_32bits(st->nfsr, 59);
+
+  const uint32_t b40 = get_32bits(st->nfsr, 40);
+  const uint32_t b48 = get_32bits(st->nfsr, 48);
+
+  const uint32_t b61 = get_32bits(st->nfsr, 61);
+  const uint32_t b65 = get_32bits(st->nfsr, 65);
+
+  const uint32_t b68 = get_32bits(st->nfsr, 68);
+  const uint32_t b84 = get_32bits(st->nfsr, 84);
+
+  const uint32_t b22 = get_32bits(st->nfsr, 22);
+  const uint32_t b24 = get_32bits(st->nfsr, 24);
+  const uint32_t b25 = get_32bits(st->nfsr, 25);
+
+  const uint32_t b70 = get_32bits(st->nfsr, 70);
+  const uint32_t b78 = get_32bits(st->nfsr, 78);
+  const uint32_t b82 = get_32bits(st->nfsr, 82);
+
+  const uint32_t b88 = get_32bits(st->nfsr, 88);
+  const uint32_t b92 = get_32bits(st->nfsr, 92);
+  const uint32_t b93 = get_32bits(st->nfsr, 93);
+  const uint32_t b95 = get_32bits(st->nfsr, 95);
+
+  const uint32_t t0 = b0 ^ b26 ^ b56 ^ b91 ^ b96;
+  const uint32_t t1 = b3 & b67;
+  const uint32_t t2 = b11 & b13;
+  const uint32_t t3 = b17 & b18;
+  const uint32_t t4 = b27 & b59;
+  const uint32_t t5 = b40 & b48;
+  const uint32_t t6 = b61 & b65;
+  const uint32_t t7 = b68 & b84;
+  const uint32_t t8 = b22 & b24 & b25;
+  const uint32_t t9 = b70 & b78 & b82;
+  const uint32_t t10 = b88 & b92 & b93 & b95;
+
+  const uint32_t fbt = t0 ^ t1 ^ t2 ^ t3 ^ t4 ^ t5 ^ t6 ^ t7 ^ t8 ^ t9 ^ t10;
+  const uint32_t res = s0 ^ fbt;
+  return res;
 }
 
 // Updates 128 -bit register by dropping bit [0..8) & setting new bit [120..128)

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -38,6 +38,26 @@ compute_index(
   return std::make_pair(off, boff);
 }
 
+// Given a byte array and a starting bit index ( in that byte array ), this
+// routine extracts out 8 consecutive bits ( all indexing starts from 0 )
+// starting from provided bit index | end index is calculated as (sidx + 7)
+inline static constexpr uint8_t
+get_8bits(const uint8_t* const arr, const size_t sidx)
+{
+  const size_t eidx = sidx + 7ul;
+
+  const auto sidx_ = compute_index(sidx);
+  const auto eidx_ = compute_index(eidx);
+
+  const uint8_t lo = arr[sidx_.first] >> sidx_.second;
+  const uint8_t hi = arr[eidx_.first] << (7ul - eidx_.second);
+
+  const bool flg = (sidx & 7ul) == 0ul;
+  const uint8_t bits = hi | (lo * !flg);
+
+  return bits;
+}
+
 // Given a byte array and an index pair in terms of a byte offset & a bit offset
 // ( inside the byte, which itself is selected using byte offset argument ),
 // this routine extracts out the bit and places it in least significant position

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -71,24 +71,30 @@ get_32bits(const uint8_t* const arr, const size_t sidx)
   const auto sidx_ = compute_index(sidx);
   const auto eidx_ = compute_index(eidx);
 
-  const uint8_t lo = arr[sidx_.first] >> sidx_.second;
-  const uint8_t hi = arr[eidx_.first] << (7ul - eidx_.second);
+  const size_t mbytes = eidx_.first - sidx_.first - 1ul;
 
-  const size_t mid_bytes = eidx_.first - sidx_.first + 1ul;
+  const size_t lsb_cnt = 8ul - sidx_.second;
+  const size_t mid_cnt = mbytes << 3;
+
+  const size_t hi_off = 7ul - eidx_.second;
+  const size_t msb_off = mid_cnt + lsb_cnt;
+
+  const uint8_t lo = arr[sidx_.first] >> sidx_.second;
+  const uint8_t hi = (arr[eidx_.first] << hi_off) >> hi_off;
 
   const uint32_t lsb = static_cast<uint32_t>(lo);
-  const uint32_t msb = static_cast<uint32_t>(hi) << (mid_bytes << 3);
+  const uint32_t msb = static_cast<uint32_t>(hi) << msb_off;
 
   uint32_t mid = 0u;
 
-  for (size_t i = 0; i < mid_bytes; i++) {
+  for (size_t i = 0; i < mbytes; i++) {
     const size_t off = sidx_.first + 1ul;
     const size_t boff = i << 3;
 
     mid |= static_cast<uint32_t>(arr[off + i]) << boff;
   }
 
-  const uint32_t res = msb | (mid << (8ul - sidx_.second)) | lsb;
+  const uint32_t res = msb | (mid << lsb_cnt) | lsb;
   return res;
 }
 

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -243,6 +243,25 @@ l(const state_t* const st)
   return s120;
 }
 
+// L(St) --- update function of LFSR, computing 32 bits of LFSR ( starting from
+// bit index 96 ), for next 32 cipher clock rounds, in parallel
+//
+// See definition in page 7 of Grain-128 AEAD specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/grain-128aead-spec-final.pdf
+inline static uint32_t
+lx32(const state_t* const st)
+{
+  const uint32_t s0 = get_32bits(st->lfsr, 0);
+  const uint32_t s7 = get_32bits(st->lfsr, 7);
+  const uint32_t s38 = get_32bits(st->lfsr, 38);
+  const uint32_t s70 = get_32bits(st->lfsr, 70);
+  const uint32_t s81 = get_32bits(st->lfsr, 81);
+  const uint32_t s96 = get_32bits(st->lfsr, 96);
+
+  const uint32_t s120 = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
+  return s120;
+}
+
 // s0 + F(Bt) --- update function of NFSR, computing 8 bits of NFSR ( starting
 // from bit index 120 ), for next eight cipher clock rounds
 //


### PR DESCRIPTION
- Execute 8 consecutive clock cycles of stream cipher at a time
- Previously only 1 -bit was consumed at a time
- It should ideally generate ~8x speed up