### PR TITLE
Parallel Execution of 32 cycles during authentication/ encryption: ~4.5x speed up 🌟

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ make benchmark
 
 Note that, when benchmarking, associated data length is always kept 32 -bytes, while variable length ( = L ) plain text is used | L ∈ [64..4096] && L = 2 ^ i.
 
-> Note, in this implementation, 8 consecutive cycles of Grain-128 AEAD stream cipher are executed in parallel, after cipher internal state is initialized. During execution of initialization phase, 32 consecutive clocks are executed in parallel ( initialization is done by clocking cipher state 512 times ).
+> Note, in this implementation, 8/ 32 ( preferred ) consecutive cycles of Grain-128 AEAD stream cipher are executed in parallel, after cipher internal state is initialized. During execution of initialization phase, 32 consecutive clocks are executed in parallel ( initialization is done by clocking cipher state 512 times ).
 
 ### On AWS Graviton3
 
 ```bash
-2022-08-14T06:07:17+00:00
+2022-08-31T12:25:47+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -124,60 +124,60 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.14, 0.03, 0.01
+Load Average: 0.05, 0.01, 0.00
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         7939 ns         7939 ns        88196 bytes_per_second=11.5326M/s
-bench_grain_128aead::decrypt/32/64         8216 ns         8216 ns        85203 bytes_per_second=11.1437M/s
-bench_grain_128aead::encrypt/32/128       10372 ns        10372 ns        67486 bytes_per_second=14.7116M/s
-bench_grain_128aead::decrypt/32/128       10818 ns        10818 ns        64707 bytes_per_second=14.1047M/s
-bench_grain_128aead::encrypt/32/256       15211 ns        15211 ns        46024 bytes_per_second=18.0565M/s
-bench_grain_128aead::decrypt/32/256       16018 ns        16017 ns        43697 bytes_per_second=17.1474M/s
-bench_grain_128aead::encrypt/32/512       24851 ns        24850 ns        28168 bytes_per_second=20.8769M/s
-bench_grain_128aead::decrypt/32/512       26413 ns        26412 ns        26502 bytes_per_second=19.6423M/s
-bench_grain_128aead::encrypt/32/1024      44278 ns        44277 ns        15877 bytes_per_second=22.745M/s
-bench_grain_128aead::decrypt/32/1024      46972 ns        46971 ns        14902 bytes_per_second=21.4405M/s
-bench_grain_128aead::encrypt/32/2048      82530 ns        82528 ns         8481 bytes_per_second=24.0359M/s
-bench_grain_128aead::decrypt/32/2048      88755 ns        88753 ns         7887 bytes_per_second=22.3502M/s
-bench_grain_128aead::encrypt/32/4096     159410 ns       159406 ns         4391 bytes_per_second=24.6965M/s
-bench_grain_128aead::decrypt/32/4096     171819 ns       171815 ns         4074 bytes_per_second=22.9128M/s
+bench_grain_128aead::encrypt/32/64         2506 ns         2506 ns       279308 bytes_per_second=36.5397M/s
+bench_grain_128aead::decrypt/32/64         2456 ns         2456 ns       285072 bytes_per_second=37.2781M/s
+bench_grain_128aead::encrypt/32/128        3930 ns         3930 ns       178112 bytes_per_second=38.8301M/s
+bench_grain_128aead::decrypt/32/128        3811 ns         3811 ns       183671 bytes_per_second=40.0374M/s
+bench_grain_128aead::encrypt/32/256        6778 ns         6778 ns       103258 bytes_per_second=40.524M/s
+bench_grain_128aead::decrypt/32/256        6521 ns         6521 ns       107332 bytes_per_second=42.1176M/s
+bench_grain_128aead::encrypt/32/512       12470 ns        12470 ns        56131 bytes_per_second=41.6049M/s
+bench_grain_128aead::decrypt/32/512       11944 ns        11944 ns        58577 bytes_per_second=43.4367M/s
+bench_grain_128aead::encrypt/32/1024      23863 ns        23862 ns        29333 bytes_per_second=42.2051M/s
+bench_grain_128aead::decrypt/32/1024      22771 ns        22771 ns        30741 bytes_per_second=44.2265M/s
+bench_grain_128aead::encrypt/32/2048      46640 ns        46639 ns        15008 bytes_per_second=42.532M/s
+bench_grain_128aead::decrypt/32/2048      44395 ns        44394 ns        15773 bytes_per_second=44.6828M/s
+bench_grain_128aead::encrypt/32/4096      92076 ns        92074 ns         7598 bytes_per_second=42.7564M/s
+bench_grain_128aead::decrypt/32/4096      87705 ns        87703 ns         7981 bytes_per_second=44.8873M/s
 ```
 
 ### On AWS Graviton2
 
 ```bash
-2022-08-14T06:06:26+00:00
+2022-08-31T12:24:25+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.08, 0.02, 0.01
+Load Average: 0.15, 0.03, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        11443 ns        11443 ns        61134 bytes_per_second=8.0006M/s
-bench_grain_128aead::decrypt/32/64        11454 ns        11454 ns        61115 bytes_per_second=7.99341M/s
-bench_grain_128aead::encrypt/32/128       17126 ns        17126 ns        40875 bytes_per_second=8.90969M/s
-bench_grain_128aead::decrypt/32/128       17136 ns        17135 ns        40849 bytes_per_second=8.90481M/s
-bench_grain_128aead::encrypt/32/256       28489 ns        28489 ns        24571 bytes_per_second=9.64093M/s
-bench_grain_128aead::decrypt/32/256       28500 ns        28500 ns        24561 bytes_per_second=9.63716M/s
-bench_grain_128aead::encrypt/32/512       51218 ns        51217 ns        13667 bytes_per_second=10.1295M/s
-bench_grain_128aead::decrypt/32/512       51231 ns        51228 ns        13665 bytes_per_second=10.1272M/s
-bench_grain_128aead::encrypt/32/1024      96671 ns        96670 ns         7240 bytes_per_second=10.4177M/s
-bench_grain_128aead::decrypt/32/1024      96690 ns        96687 ns         7240 bytes_per_second=10.4159M/s
-bench_grain_128aead::encrypt/32/2048     187590 ns       187585 ns         3732 bytes_per_second=10.5746M/s
-bench_grain_128aead::decrypt/32/2048     187619 ns       187614 ns         3731 bytes_per_second=10.573M/s
-bench_grain_128aead::encrypt/32/4096     369432 ns       369426 ns         1895 bytes_per_second=10.6564M/s
-bench_grain_128aead::decrypt/32/4096     369445 ns       369433 ns         1895 bytes_per_second=10.6562M/s
+bench_grain_128aead::encrypt/32/64         4205 ns         4205 ns       166463 bytes_per_second=21.7718M/s
+bench_grain_128aead::decrypt/32/64         4300 ns         4300 ns       162793 bytes_per_second=21.2925M/s
+bench_grain_128aead::encrypt/32/128        6580 ns         6579 ns       106368 bytes_per_second=23.1915M/s
+bench_grain_128aead::decrypt/32/128        6737 ns         6737 ns       103904 bytes_per_second=22.6501M/s
+bench_grain_128aead::encrypt/32/256       11328 ns        11328 ns        61792 bytes_per_second=24.2458M/s
+bench_grain_128aead::decrypt/32/256       11610 ns        11610 ns        60286 bytes_per_second=23.6562M/s
+bench_grain_128aead::encrypt/32/512       20825 ns        20825 ns        33612 bytes_per_second=24.9123M/s
+bench_grain_128aead::decrypt/32/512       21358 ns        21358 ns        32773 bytes_per_second=24.2908M/s
+bench_grain_128aead::encrypt/32/1024      39821 ns        39820 ns        17579 bytes_per_second=25.2908M/s
+bench_grain_128aead::decrypt/32/1024      40854 ns        40854 ns        17135 bytes_per_second=24.6508M/s
+bench_grain_128aead::encrypt/32/2048      77815 ns        77810 ns         8995 bytes_per_second=25.4933M/s
+bench_grain_128aead::decrypt/32/2048      79846 ns        79845 ns         8766 bytes_per_second=24.8437M/s
+bench_grain_128aead::encrypt/32/4096     153787 ns       153786 ns         4552 bytes_per_second=25.5989M/s
+bench_grain_128aead::decrypt/32/4096     157832 ns       157829 ns         4435 bytes_per_second=24.9432M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-08-14T10:04:14+04:00
+2022-08-31T16:22:03+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -185,30 +185,30 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.71, 2.33, 2.33
+Load Average: 1.74, 1.65, 1.68
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         5431 ns         5428 ns       120159 bytes_per_second=16.8669M/s
-bench_grain_128aead::decrypt/32/64         5443 ns         5438 ns       121926 bytes_per_second=16.837M/s
-bench_grain_128aead::encrypt/32/128        8501 ns         8493 ns        78511 bytes_per_second=17.9655M/s
-bench_grain_128aead::decrypt/32/128        8652 ns         8620 ns        81125 bytes_per_second=17.7015M/s
-bench_grain_128aead::encrypt/32/256       16225 ns        16010 ns        45959 bytes_per_second=17.1549M/s
-bench_grain_128aead::decrypt/32/256       16612 ns        16383 ns        41319 bytes_per_second=16.7652M/s
-bench_grain_128aead::encrypt/32/512       30356 ns        29256 ns        25416 bytes_per_second=17.7328M/s
-bench_grain_128aead::decrypt/32/512       27383 ns        27331 ns        24107 bytes_per_second=18.9822M/s
-bench_grain_128aead::encrypt/32/1024      55254 ns        54708 ns        13409 bytes_per_second=18.4081M/s
-bench_grain_128aead::decrypt/32/1024      55436 ns        54904 ns        12272 bytes_per_second=18.3425M/s
-bench_grain_128aead::encrypt/32/2048     103929 ns       103547 ns         6767 bytes_per_second=19.1569M/s
-bench_grain_128aead::decrypt/32/2048     111206 ns       108785 ns         6634 bytes_per_second=18.2346M/s
-bench_grain_128aead::encrypt/32/4096     201916 ns       201604 ns         3353 bytes_per_second=19.5272M/s
-bench_grain_128aead::decrypt/32/4096     213681 ns       211716 ns         3439 bytes_per_second=18.5945M/s
+bench_grain_128aead::encrypt/32/64         1453 ns         1451 ns       466614 bytes_per_second=63.1063M/s
+bench_grain_128aead::decrypt/32/64         1462 ns         1461 ns       476547 bytes_per_second=62.6804M/s
+bench_grain_128aead::encrypt/32/128        2179 ns         2178 ns       318384 bytes_per_second=70.0644M/s
+bench_grain_128aead::decrypt/32/128        2169 ns         2168 ns       318480 bytes_per_second=70.3666M/s
+bench_grain_128aead::encrypt/32/256        3651 ns         3648 ns       190775 bytes_per_second=75.2873M/s
+bench_grain_128aead::decrypt/32/256        3632 ns         3629 ns       192214 bytes_per_second=75.6859M/s
+bench_grain_128aead::encrypt/32/512        6645 ns         6638 ns       103301 bytes_per_second=78.1543M/s
+bench_grain_128aead::decrypt/32/512        6540 ns         6534 ns       104490 bytes_per_second=79.4022M/s
+bench_grain_128aead::encrypt/32/1024      12507 ns        12502 ns        54486 bytes_per_second=80.5554M/s
+bench_grain_128aead::decrypt/32/1024      12421 ns        12412 ns        55613 bytes_per_second=81.1347M/s
+bench_grain_128aead::encrypt/32/2048      24295 ns        24281 ns        28632 bytes_per_second=81.6966M/s
+bench_grain_128aead::decrypt/32/2048      24457 ns        24436 ns        28425 bytes_per_second=81.1757M/s
+bench_grain_128aead::encrypt/32/4096      48003 ns        47955 ns        14618 bytes_per_second=82.0922M/s
+bench_grain_128aead::decrypt/32/4096      48276 ns        48254 ns        13964 bytes_per_second=81.5837M/s
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
 
 ```bash
-2022-08-14T06:05:20+00:00
+2022-08-31T12:28:04+00:00
 Running ./bench/a.out
 Run on (4 X 2300 MHz CPU s)
 CPU Caches:
@@ -216,24 +216,24 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.14, 0.03, 0.01
+Load Average: 0.33, 0.10, 0.03
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64        14046 ns        14045 ns        49790 bytes_per_second=6.51851M/s
-bench_grain_128aead::decrypt/32/64        13666 ns        13666 ns        51215 bytes_per_second=6.69953M/s
-bench_grain_128aead::encrypt/32/128       19346 ns        19346 ns        36204 bytes_per_second=7.88721M/s
-bench_grain_128aead::decrypt/32/128       18892 ns        18892 ns        37063 bytes_per_second=8.07689M/s
-bench_grain_128aead::encrypt/32/256       29962 ns        29962 ns        23377 bytes_per_second=9.16683M/s
-bench_grain_128aead::decrypt/32/256       29288 ns        29289 ns        23906 bytes_per_second=9.37763M/s
-bench_grain_128aead::encrypt/32/512       51059 ns        51056 ns        13697 bytes_per_second=10.1614M/s
-bench_grain_128aead::decrypt/32/512       50028 ns        50029 ns        10000 bytes_per_second=10.3701M/s
-bench_grain_128aead::encrypt/32/1024      93829 ns        93830 ns         7491 bytes_per_second=10.7331M/s
-bench_grain_128aead::decrypt/32/1024      91690 ns        91690 ns         7646 bytes_per_second=10.9835M/s
-bench_grain_128aead::encrypt/32/2048     178232 ns       178233 ns         3934 bytes_per_second=11.1295M/s
-bench_grain_128aead::decrypt/32/2048     174480 ns       174457 ns         4010 bytes_per_second=11.3704M/s
-bench_grain_128aead::encrypt/32/4096     346932 ns       346907 ns         2019 bytes_per_second=11.3482M/s
-bench_grain_128aead::decrypt/32/4096     340194 ns       340168 ns         2058 bytes_per_second=11.573M/s
+bench_grain_128aead::encrypt/32/64         3619 ns         3619 ns       195348 bytes_per_second=25.2991M/s
+bench_grain_128aead::decrypt/32/64         3789 ns         3789 ns       184952 bytes_per_second=24.1653M/s
+bench_grain_128aead::encrypt/32/128        5232 ns         5232 ns       133591 bytes_per_second=29.1669M/s
+bench_grain_128aead::decrypt/32/128        5621 ns         5621 ns       124339 bytes_per_second=27.1447M/s
+bench_grain_128aead::encrypt/32/256        8499 ns         8499 ns        82400 bytes_per_second=32.3173M/s
+bench_grain_128aead::decrypt/32/256        9139 ns         9139 ns        76565 bytes_per_second=30.0546M/s
+bench_grain_128aead::encrypt/32/512       15039 ns        15037 ns        46525 bytes_per_second=34.5006M/s
+bench_grain_128aead::decrypt/32/512       16307 ns        16306 ns        42871 bytes_per_second=31.8155M/s
+bench_grain_128aead::encrypt/32/1024      28187 ns        28184 ns        24827 bytes_per_second=35.7327M/s
+bench_grain_128aead::decrypt/32/1024      30596 ns        30595 ns        22879 bytes_per_second=32.9164M/s
+bench_grain_128aead::encrypt/32/2048      54417 ns        54417 ns        12864 bytes_per_second=36.4529M/s
+bench_grain_128aead::decrypt/32/2048      59023 ns        59020 ns        11836 bytes_per_second=33.6099M/s
+bench_grain_128aead::encrypt/32/4096     106662 ns       106663 ns         6572 bytes_per_second=36.9085M/s
+bench_grain_128aead::decrypt/32/4096     116021 ns       116022 ns         6030 bytes_per_second=33.9313M/s
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Note that, when benchmarking, associated data length is always kept 32 -bytes, w
 ### On AWS Graviton3
 
 ```bash
-2022-08-31T12:25:47+00:00
+2022-08-31T16:05:56+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -124,54 +124,54 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.05, 0.01, 0.00
+Load Average: 0.00, 0.00, 0.00
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         2506 ns         2506 ns       279308 bytes_per_second=36.5397M/s
-bench_grain_128aead::decrypt/32/64         2456 ns         2456 ns       285072 bytes_per_second=37.2781M/s
-bench_grain_128aead::encrypt/32/128        3930 ns         3930 ns       178112 bytes_per_second=38.8301M/s
-bench_grain_128aead::decrypt/32/128        3811 ns         3811 ns       183671 bytes_per_second=40.0374M/s
-bench_grain_128aead::encrypt/32/256        6778 ns         6778 ns       103258 bytes_per_second=40.524M/s
-bench_grain_128aead::decrypt/32/256        6521 ns         6521 ns       107332 bytes_per_second=42.1176M/s
-bench_grain_128aead::encrypt/32/512       12470 ns        12470 ns        56131 bytes_per_second=41.6049M/s
-bench_grain_128aead::decrypt/32/512       11944 ns        11944 ns        58577 bytes_per_second=43.4367M/s
-bench_grain_128aead::encrypt/32/1024      23863 ns        23862 ns        29333 bytes_per_second=42.2051M/s
-bench_grain_128aead::decrypt/32/1024      22771 ns        22771 ns        30741 bytes_per_second=44.2265M/s
-bench_grain_128aead::encrypt/32/2048      46640 ns        46639 ns        15008 bytes_per_second=42.532M/s
-bench_grain_128aead::decrypt/32/2048      44395 ns        44394 ns        15773 bytes_per_second=44.6828M/s
-bench_grain_128aead::encrypt/32/4096      92076 ns        92074 ns         7598 bytes_per_second=42.7564M/s
-bench_grain_128aead::decrypt/32/4096      87705 ns        87703 ns         7981 bytes_per_second=44.8873M/s
+bench_grain_128aead::encrypt/32/64         2260 ns         2260 ns       309684 bytes_per_second=40.5189M/s
+bench_grain_128aead::decrypt/32/64         2297 ns         2297 ns       304639 bytes_per_second=39.8507M/s
+bench_grain_128aead::encrypt/32/128        3459 ns         3459 ns       202384 bytes_per_second=44.1175M/s
+bench_grain_128aead::decrypt/32/128        3525 ns         3525 ns       198544 bytes_per_second=43.2822M/s
+bench_grain_128aead::encrypt/32/256        5862 ns         5862 ns       119396 bytes_per_second=46.8546M/s
+bench_grain_128aead::decrypt/32/256        5984 ns         5984 ns       117008 bytes_per_second=45.8975M/s
+bench_grain_128aead::encrypt/32/512       10672 ns        10672 ns        65566 bytes_per_second=48.6149M/s
+bench_grain_128aead::decrypt/32/512       10930 ns        10930 ns        64043 bytes_per_second=47.4664M/s
+bench_grain_128aead::encrypt/32/1024      20291 ns        20290 ns        34500 bytes_per_second=49.6335M/s
+bench_grain_128aead::decrypt/32/1024      20786 ns        20785 ns        33673 bytes_per_second=48.4518M/s
+bench_grain_128aead::encrypt/32/2048      39525 ns        39524 ns        17717 bytes_per_second=50.1878M/s
+bench_grain_128aead::decrypt/32/2048      40434 ns        40433 ns        17287 bytes_per_second=49.0603M/s
+bench_grain_128aead::encrypt/32/4096      78112 ns        78110 ns         8957 bytes_per_second=50.4003M/s
+bench_grain_128aead::decrypt/32/4096      79721 ns        79719 ns         8780 bytes_per_second=49.3829M/s
 ```
 
 ### On AWS Graviton2
 
 ```bash
-2022-08-31T12:24:25+00:00
+2022-08-31T16:04:51+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.15, 0.03, 0.01
+Load Average: 0.08, 0.02, 0.01
 -----------------------------------------------------------------------------------------------
 Benchmark                                     Time             CPU   Iterations UserCounters...
 -----------------------------------------------------------------------------------------------
-bench_grain_128aead::encrypt/32/64         4205 ns         4205 ns       166463 bytes_per_second=21.7718M/s
-bench_grain_128aead::decrypt/32/64         4300 ns         4300 ns       162793 bytes_per_second=21.2925M/s
-bench_grain_128aead::encrypt/32/128        6580 ns         6579 ns       106368 bytes_per_second=23.1915M/s
-bench_grain_128aead::decrypt/32/128        6737 ns         6737 ns       103904 bytes_per_second=22.6501M/s
-bench_grain_128aead::encrypt/32/256       11328 ns        11328 ns        61792 bytes_per_second=24.2458M/s
-bench_grain_128aead::decrypt/32/256       11610 ns        11610 ns        60286 bytes_per_second=23.6562M/s
-bench_grain_128aead::encrypt/32/512       20825 ns        20825 ns        33612 bytes_per_second=24.9123M/s
-bench_grain_128aead::decrypt/32/512       21358 ns        21358 ns        32773 bytes_per_second=24.2908M/s
-bench_grain_128aead::encrypt/32/1024      39821 ns        39820 ns        17579 bytes_per_second=25.2908M/s
-bench_grain_128aead::decrypt/32/1024      40854 ns        40854 ns        17135 bytes_per_second=24.6508M/s
-bench_grain_128aead::encrypt/32/2048      77815 ns        77810 ns         8995 bytes_per_second=25.4933M/s
-bench_grain_128aead::decrypt/32/2048      79846 ns        79845 ns         8766 bytes_per_second=24.8437M/s
-bench_grain_128aead::encrypt/32/4096     153787 ns       153786 ns         4552 bytes_per_second=25.5989M/s
-bench_grain_128aead::decrypt/32/4096     157832 ns       157829 ns         4435 bytes_per_second=24.9432M/s
+bench_grain_128aead::encrypt/32/64         3815 ns         3815 ns       183503 bytes_per_second=24.0005M/s
+bench_grain_128aead::decrypt/32/64         3959 ns         3959 ns       176836 bytes_per_second=23.1279M/s
+bench_grain_128aead::encrypt/32/128        5806 ns         5806 ns       120566 bytes_per_second=26.2823M/s
+bench_grain_128aead::decrypt/32/128        6061 ns         6061 ns       115485 bytes_per_second=25.1749M/s
+bench_grain_128aead::encrypt/32/256        9788 ns         9788 ns        71513 bytes_per_second=28.06M/s
+bench_grain_128aead::decrypt/32/256       10266 ns        10266 ns        68180 bytes_per_second=26.7538M/s
+bench_grain_128aead::encrypt/32/512       17753 ns        17753 ns        39429 bytes_per_second=29.2235M/s
+bench_grain_128aead::decrypt/32/512       18677 ns        18677 ns        37480 bytes_per_second=27.7779M/s
+bench_grain_128aead::encrypt/32/1024      33683 ns        33682 ns        20781 bytes_per_second=29.8993M/s
+bench_grain_128aead::decrypt/32/1024      35499 ns        35498 ns        19719 bytes_per_second=28.3703M/s
+bench_grain_128aead::encrypt/32/2048      65545 ns        65544 ns        10679 bytes_per_second=30.2645M/s
+bench_grain_128aead::decrypt/32/2048      69141 ns        69140 ns        10124 bytes_per_second=28.6903M/s
+bench_grain_128aead::encrypt/32/4096     129270 ns       129266 ns         5415 bytes_per_second=30.4548M/s
+bench_grain_128aead::decrypt/32/4096     136443 ns       136436 ns         5130 bytes_per_second=28.8542M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -215,7 +215,7 @@ auth_associated_data(
 
     const auto splitted = split_bits(yt0, yt1);
 
-    grain_128::authenticate_byte(st, der[i], splitted.second);
+    grain_128::authenticate<uint8_t>(st, der[i], splitted.second);
   }
 
   // Authenticate associated data bits
@@ -243,7 +243,7 @@ auth_associated_data(
 
     const auto splitted = split_bits(yt0, yt1);
 
-    grain_128::authenticate_byte(st, data[i], splitted.second);
+    grain_128::authenticate<uint8_t>(st, data[i], splitted.second);
   }
 }
 
@@ -283,8 +283,8 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
 
     const auto splitted = split_bits(yt0, yt1);
 
-    enc[i] = txt[i] ^ splitted.first;                          // encrypt
-    grain_128::authenticate_byte(st, txt[i], splitted.second); // authenticate
+    enc[i] = txt[i] ^ splitted.first; // encrypt
+    grain_128::authenticate<uint8_t>(st, txt[i], splitted.second);
   }
 }
 
@@ -324,8 +324,8 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
 
     const auto splitted = split_bits(yt0, yt1);
 
-    txt[i] = enc[i] ^ splitted.first;                          // decrypt
-    grain_128::authenticate_byte(st, txt[i], splitted.second); // authenticate
+    txt[i] = enc[i] ^ splitted.first; // decrypt
+    grain_128::authenticate<uint8_t>(st, txt[i], splitted.second);
   }
 }
 
@@ -363,7 +363,7 @@ auth_padding_bit(grain_128::state_t* const st)
 
   const auto splitted = split_bits(yt0, yt1);
 
-  grain_128::authenticate_byte(st, padding, splitted.second);
+  grain_128::authenticate<uint8_t>(st, padding, splitted.second);
 }
 
 }

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -215,7 +215,7 @@ auth_associated_data(
 
     const auto splitted = split_bits(yt0, yt1);
 
-    grain_128::authenticated_byte(st, der[i], splitted.second);
+    grain_128::authenticate_byte(st, der[i], splitted.second);
   }
 
   // Authenticate associated data bits
@@ -243,7 +243,7 @@ auth_associated_data(
 
     const auto splitted = split_bits(yt0, yt1);
 
-    grain_128::authenticated_byte(st, data[i], splitted.second);
+    grain_128::authenticate_byte(st, data[i], splitted.second);
   }
 }
 
@@ -283,8 +283,8 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
 
     const auto splitted = split_bits(yt0, yt1);
 
-    enc[i] = txt[i] ^ splitted.first;                           // encrypt
-    grain_128::authenticated_byte(st, txt[i], splitted.second); // authenticate
+    enc[i] = txt[i] ^ splitted.first;                          // encrypt
+    grain_128::authenticate_byte(st, txt[i], splitted.second); // authenticate
   }
 }
 
@@ -324,8 +324,8 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
 
     const auto splitted = split_bits(yt0, yt1);
 
-    txt[i] = enc[i] ^ splitted.first;                           // decrypt
-    grain_128::authenticated_byte(st, txt[i], splitted.second); // authenticate
+    txt[i] = enc[i] ^ splitted.first;                          // decrypt
+    grain_128::authenticate_byte(st, txt[i], splitted.second); // authenticate
   }
 }
 
@@ -363,7 +363,7 @@ auth_padding_bit(grain_128::state_t* const st)
 
   const auto splitted = split_bits(yt0, yt1);
 
-  grain_128::authenticated_byte(st, padding, splitted.second);
+  grain_128::authenticate_byte(st, padding, splitted.second);
 }
 
 }

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -160,14 +160,8 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
       std::memcpy(&ka, key + ta, 4);
       std::memcpy(&kb, key + tb, 4);
     } else {
-      ka = static_cast<uint32_t>(key[ta ^ 3] << 24) |
-           static_cast<uint32_t>(key[ta ^ 2] << 16) |
-           static_cast<uint32_t>(key[ta ^ 1] << 8) |
-           static_cast<uint32_t>(key[ta ^ 0] << 0);
-      kb = static_cast<uint32_t>(key[tb ^ 3] << 24) |
-           static_cast<uint32_t>(key[tb ^ 2] << 16) |
-           static_cast<uint32_t>(key[tb ^ 1] << 8) |
-           static_cast<uint32_t>(key[tb ^ 0] << 0);
+      ka = grain_128::from_le_bytes<uint32_t>(key + ta);
+      kb = grain_128::from_le_bytes<uint32_t>(key + tb);
     }
 
     const uint32_t yt = grain_128::ksbx32(st);
@@ -187,10 +181,7 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(st->acc + toff, &yt, 4);
     } else {
-      st->acc[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
-      st->acc[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
-      st->acc[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
-      st->acc[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+      grain_128::to_le_bytes<uint32_t>(yt, st->acc + toff);
     }
 
     const uint32_t s96 = grain_128::lx32(st);
@@ -208,10 +199,7 @@ initialize(grain_128::state_t* const __restrict st, // Grain-128 AEAD state
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(st->sreg + toff, &yt, 4);
     } else {
-      st->sreg[toff ^ 0] = static_cast<uint8_t>(yt >> 0);
-      st->sreg[toff ^ 1] = static_cast<uint8_t>(yt >> 8);
-      st->sreg[toff ^ 2] = static_cast<uint8_t>(yt >> 16);
-      st->sreg[toff ^ 3] = static_cast<uint8_t>(yt >> 24);
+      grain_128::to_le_bytes<uint32_t>(yt, st->sreg + toff);
     }
 
     const uint32_t s96 = grain_128::lx32(st);
@@ -299,10 +287,7 @@ auth_associated_data(
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(&dataw, data + off, 4);
     } else {
-      dataw = static_cast<uint32_t>(data[off ^ 3] << 24) |
-              static_cast<uint32_t>(data[off ^ 2] << 16) |
-              static_cast<uint32_t>(data[off ^ 1] << 8) |
-              static_cast<uint32_t>(data[off ^ 0] << 0);
+      dataw = grain_128::from_le_bytes<uint32_t>(data + off);
     }
 
     const auto splitted = split_bits<uint32_t>(yt0, yt1);
@@ -383,10 +368,7 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(&txtw, txt + off, 4);
     } else {
-      txtw = static_cast<uint32_t>(txt[off ^ 3] << 24) |
-             static_cast<uint32_t>(txt[off ^ 2] << 16) |
-             static_cast<uint32_t>(txt[off ^ 1] << 8) |
-             static_cast<uint32_t>(txt[off ^ 0] << 0);
+      txtw = grain_128::from_le_bytes<uint32_t>(txt + off);
     }
 
     const uint32_t encw = txtw ^ splitted.first; // encrypt
@@ -394,10 +376,7 @@ enc_and_auth_txt(grain_128::state_t* const __restrict st,
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(enc + off, &encw, 4);
     } else {
-      enc[off ^ 0] = static_cast<uint8_t>(encw >> 0);
-      enc[off ^ 1] = static_cast<uint8_t>(encw >> 8);
-      enc[off ^ 2] = static_cast<uint8_t>(encw >> 16);
-      enc[off ^ 3] = static_cast<uint8_t>(encw >> 24);
+      grain_128::to_le_bytes<uint32_t>(encw, enc + off);
     }
 
     grain_128::authenticate<uint32_t>(st, txtw, splitted.second);
@@ -480,10 +459,7 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(&encw, enc + off, 4);
     } else {
-      encw = static_cast<uint32_t>(enc[off ^ 3] << 24) |
-             static_cast<uint32_t>(enc[off ^ 2] << 16) |
-             static_cast<uint32_t>(enc[off ^ 1] << 8) |
-             static_cast<uint32_t>(enc[off ^ 0] << 0);
+      encw = grain_128::from_le_bytes<uint32_t>(enc + off);
     }
 
     const uint32_t txtw = encw ^ splitted.first; // decrypt
@@ -491,10 +467,7 @@ dec_and_auth_txt(grain_128::state_t* const __restrict st,
     if constexpr (std::endian::native == std::endian::little) {
       std::memcpy(txt + off, &txtw, 4);
     } else {
-      txt[off ^ 0] = static_cast<uint8_t>(txtw >> 0);
-      txt[off ^ 1] = static_cast<uint8_t>(txtw >> 8);
-      txt[off ^ 2] = static_cast<uint8_t>(txtw >> 16);
-      txt[off ^ 3] = static_cast<uint8_t>(txtw >> 24);
+      grain_128::to_le_bytes<uint32_t>(txtw, txt + off);
     }
 
     grain_128::authenticate<uint32_t>(st, txtw, splitted.second);

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -173,15 +173,23 @@ h(const state_t* const st)
 inline static uint32_t
 hx32(const state_t* const st)
 {
-  const uint32_t nfsr[]{ from_le_bytes<uint32_t>(st->nfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 12ul) };
+  uint32_t nfsr[4]{};
+  uint32_t lfsr[4]{};
 
-  const uint32_t lfsr[]{ from_le_bytes<uint32_t>(st->lfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 12ul) };
+  if constexpr (std::endian::native == std::endian::little) {
+    std::memcpy(nfsr, st->nfsr, 16);
+    std::memcpy(lfsr, st->lfsr, 16);
+  } else {
+    nfsr[0] = from_le_bytes<uint32_t>(st->nfsr + 0ul);
+    nfsr[1] = from_le_bytes<uint32_t>(st->nfsr + 4ul);
+    nfsr[2] = from_le_bytes<uint32_t>(st->nfsr + 8ul);
+    nfsr[3] = from_le_bytes<uint32_t>(st->nfsr + 12ul);
+
+    lfsr[0] = from_le_bytes<uint32_t>(st->lfsr + 0ul);
+    lfsr[1] = from_le_bytes<uint32_t>(st->lfsr + 4ul);
+    lfsr[2] = from_le_bytes<uint32_t>(st->lfsr + 8ul);
+    lfsr[3] = from_le_bytes<uint32_t>(st->lfsr + 12ul);
+  }
 
   const uint32_t x0 = get_32bits<12ul>(nfsr);
   const uint32_t x1 = get_32bits<8ul>(lfsr);
@@ -245,15 +253,23 @@ ksb(const state_t* const st)
 inline static uint32_t
 ksbx32(const state_t* const st)
 {
-  const uint32_t nfsr[]{ from_le_bytes<uint32_t>(st->nfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 12ul) };
+  uint32_t nfsr[4]{};
+  uint32_t lfsr[4]{};
 
-  const uint32_t lfsr[]{ from_le_bytes<uint32_t>(st->lfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 12ul) };
+  if constexpr (std::endian::native == std::endian::little) {
+    std::memcpy(nfsr, st->nfsr, 16);
+    std::memcpy(lfsr, st->lfsr, 16);
+  } else {
+    nfsr[0] = from_le_bytes<uint32_t>(st->nfsr + 0ul);
+    nfsr[1] = from_le_bytes<uint32_t>(st->nfsr + 4ul);
+    nfsr[2] = from_le_bytes<uint32_t>(st->nfsr + 8ul);
+    nfsr[3] = from_le_bytes<uint32_t>(st->nfsr + 12ul);
+
+    lfsr[0] = from_le_bytes<uint32_t>(st->lfsr + 0ul);
+    lfsr[1] = from_le_bytes<uint32_t>(st->lfsr + 4ul);
+    lfsr[2] = from_le_bytes<uint32_t>(st->lfsr + 8ul);
+    lfsr[3] = from_le_bytes<uint32_t>(st->lfsr + 12ul);
+  }
 
   const uint32_t hx = hx32(st);
 
@@ -300,10 +316,16 @@ l(const state_t* const st)
 inline static uint32_t
 lx32(const state_t* const st)
 {
-  const uint32_t lfsr[]{ from_le_bytes<uint32_t>(st->lfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->lfsr + 12ul) };
+  uint32_t lfsr[4]{};
+
+  if constexpr (std::endian::native == std::endian::little) {
+    std::memcpy(lfsr, st->lfsr, 16);
+  } else {
+    lfsr[0] = from_le_bytes<uint32_t>(st->lfsr + 0ul);
+    lfsr[1] = from_le_bytes<uint32_t>(st->lfsr + 4ul);
+    lfsr[2] = from_le_bytes<uint32_t>(st->lfsr + 8ul);
+    lfsr[3] = from_le_bytes<uint32_t>(st->lfsr + 12ul);
+  }
 
   const uint32_t s0 = get_32bits<0ul>(lfsr);
   const uint32_t s7 = get_32bits<7ul>(lfsr);
@@ -391,10 +413,16 @@ f(const state_t* const st)
 inline static uint32_t
 fx32(const state_t* const st)
 {
-  const uint32_t nfsr[]{ from_le_bytes<uint32_t>(st->nfsr + 0ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 4ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 8ul),
-                         from_le_bytes<uint32_t>(st->nfsr + 12ul) };
+  uint32_t nfsr[4]{};
+
+  if constexpr (std::endian::native == std::endian::little) {
+    std::memcpy(nfsr, st->nfsr, 16);
+  } else {
+    nfsr[0] = from_le_bytes<uint32_t>(st->nfsr + 0ul);
+    nfsr[1] = from_le_bytes<uint32_t>(st->nfsr + 4ul);
+    nfsr[2] = from_le_bytes<uint32_t>(st->nfsr + 8ul);
+    nfsr[3] = from_le_bytes<uint32_t>(st->nfsr + 12ul);
+  }
 
   const uint32_t s0 = from_le_bytes<uint32_t>(st->lfsr + 0ul);
 

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -531,7 +531,7 @@ to_le_bytes(const uint64_t v, uint8_t* const bytes)
 }
 
 // Compile-time check that either 8 or 32 -bits are attempted to be
-// authenticated at a time.
+// encrypted/ authenticated at a time.
 template<typename T>
 inline static constexpr bool
 check_auth_bit_width()

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -27,14 +27,15 @@ struct state_t
 
 // Given a byte array and a starting bit index ( in that byte array ), this
 // routine extracts out 8 consecutive bits ( all indexing starts from 0 )
-// starting from provided bit index | end index is calculated as (sidx + 7)
+// starting from provided bit index s.t. end index is calculated as (sidx + 7)
+template<const size_t sidx>
 inline static constexpr uint8_t
-get_8bits(const uint8_t* const arr, const size_t sidx)
+get_8bits(const uint8_t* const arr)
 {
-  const size_t eidx = sidx + 7ul;
+  constexpr size_t eidx = sidx + 7ul;
 
-  const auto sidx_ = std::make_pair(sidx >> 3, sidx & 7ul);
-  const auto eidx_ = std::make_pair(eidx >> 3, eidx & 7ul);
+  constexpr auto sidx_ = std::make_pair(sidx >> 3, sidx & 7ul);
+  constexpr auto eidx_ = std::make_pair(eidx >> 3, eidx & 7ul);
 
   const uint8_t lo = arr[sidx_.first] >> sidx_.second;
   const uint8_t hi = arr[eidx_.first] << (7ul - eidx_.second);
@@ -47,15 +48,16 @@ get_8bits(const uint8_t* const arr, const size_t sidx)
 
 // Given a word ( each word is 32 -bit wide ) array and a starting bit index (
 // in that word array ), this routine extracts out 32 consecutive bits ( all
-// indexing starts from 0 ) starting from provided bit index | end index is
+// indexing starts from 0 ) starting from provided bit index s.t. end index is
 // calculated as (sidx + 31)
+template<const size_t sidx>
 inline static constexpr uint32_t
-get_32bits(const uint32_t* const arr, const size_t sidx)
+get_32bits(const uint32_t* const arr)
 {
-  const size_t eidx = sidx + 31ul;
+  constexpr size_t eidx = sidx + 31ul;
 
-  const auto sidx_ = std::make_pair(sidx >> 5, sidx & 31ul);
-  const auto eidx_ = std::make_pair(eidx >> 5, eidx & 31ul);
+  constexpr auto sidx_ = std::make_pair(sidx >> 5, sidx & 31ul);
+  constexpr auto eidx_ = std::make_pair(eidx >> 5, eidx & 31ul);
 
   const uint32_t lo = arr[sidx_.first] >> sidx_.second;
   const uint32_t hi = arr[eidx_.first] << (31ul - eidx_.second);
@@ -135,15 +137,15 @@ to_le_bytes(const T v, uint8_t* const bytes) requires(check_type_bit_width<T>())
 inline static uint8_t
 h(const state_t* const st)
 {
-  const uint8_t x0 = get_8bits(st->nfsr, 12);
-  const uint8_t x1 = get_8bits(st->lfsr, 8);
-  const uint8_t x2 = get_8bits(st->lfsr, 13);
-  const uint8_t x3 = get_8bits(st->lfsr, 20);
-  const uint8_t x4 = get_8bits(st->nfsr, 95);
-  const uint8_t x5 = get_8bits(st->lfsr, 42);
-  const uint8_t x6 = get_8bits(st->lfsr, 60);
-  const uint8_t x7 = get_8bits(st->lfsr, 79);
-  const uint8_t x8 = get_8bits(st->lfsr, 94);
+  const uint8_t x0 = get_8bits<12ul>(st->nfsr);
+  const uint8_t x1 = get_8bits<8ul>(st->lfsr);
+  const uint8_t x2 = get_8bits<13ul>(st->lfsr);
+  const uint8_t x3 = get_8bits<20ul>(st->lfsr);
+  const uint8_t x4 = get_8bits<95ul>(st->nfsr);
+  const uint8_t x5 = get_8bits<42ul>(st->lfsr);
+  const uint8_t x6 = get_8bits<60ul>(st->lfsr);
+  const uint8_t x7 = get_8bits<79ul>(st->lfsr);
+  const uint8_t x8 = get_8bits<94ul>(st->lfsr);
 
   const uint8_t x0x1 = x0 & x1;
   const uint8_t x2x3 = x2 & x3;
@@ -181,15 +183,15 @@ hx32(const state_t* const st)
                          from_le_bytes<uint32_t>(st->lfsr + 8ul),
                          from_le_bytes<uint32_t>(st->lfsr + 12ul) };
 
-  const uint32_t x0 = get_32bits(nfsr, 12);
-  const uint32_t x1 = get_32bits(lfsr, 8);
-  const uint32_t x2 = get_32bits(lfsr, 13);
-  const uint32_t x3 = get_32bits(lfsr, 20);
-  const uint32_t x4 = get_32bits(nfsr, 95);
-  const uint32_t x5 = get_32bits(lfsr, 42);
-  const uint32_t x6 = get_32bits(lfsr, 60);
-  const uint32_t x7 = get_32bits(lfsr, 79);
-  const uint32_t x8 = get_32bits(lfsr, 94);
+  const uint32_t x0 = get_32bits<12ul>(nfsr);
+  const uint32_t x1 = get_32bits<8ul>(lfsr);
+  const uint32_t x2 = get_32bits<13ul>(lfsr);
+  const uint32_t x3 = get_32bits<20ul>(lfsr);
+  const uint32_t x4 = get_32bits<95ul>(nfsr);
+  const uint32_t x5 = get_32bits<42ul>(lfsr);
+  const uint32_t x6 = get_32bits<60ul>(lfsr);
+  const uint32_t x7 = get_32bits<79ul>(lfsr);
+  const uint32_t x8 = get_32bits<94ul>(lfsr);
 
   const uint32_t x0x1 = x0 & x1;
   const uint32_t x2x3 = x2 & x3;
@@ -215,15 +217,15 @@ ksb(const state_t* const st)
 {
   const uint8_t hx = h(st);
 
-  const uint8_t s93 = get_8bits(st->lfsr, 93);
+  const uint8_t s93 = get_8bits<93ul>(st->lfsr);
 
-  const uint8_t b2 = get_8bits(st->nfsr, 2);
-  const uint8_t b15 = get_8bits(st->nfsr, 15);
-  const uint8_t b36 = get_8bits(st->nfsr, 36);
-  const uint8_t b45 = get_8bits(st->nfsr, 45);
-  const uint8_t b64 = get_8bits(st->nfsr, 64);
-  const uint8_t b73 = get_8bits(st->nfsr, 73);
-  const uint8_t b89 = get_8bits(st->nfsr, 89);
+  const uint8_t b2 = get_8bits<2ul>(st->nfsr);
+  const uint8_t b15 = get_8bits<15ul>(st->nfsr);
+  const uint8_t b36 = get_8bits<36ul>(st->nfsr);
+  const uint8_t b45 = get_8bits<45ul>(st->nfsr);
+  const uint8_t b64 = get_8bits<64ul>(st->nfsr);
+  const uint8_t b73 = get_8bits<73ul>(st->nfsr);
+  const uint8_t b89 = get_8bits<89ul>(st->nfsr);
 
   const uint8_t bt = b2 ^ b15 ^ b36 ^ b45 ^ b64 ^ b73 ^ b89;
 
@@ -255,15 +257,15 @@ ksbx32(const state_t* const st)
 
   const uint32_t hx = hx32(st);
 
-  const uint32_t s93 = get_32bits(lfsr, 93);
+  const uint32_t s93 = get_32bits<93ul>(lfsr);
 
-  const uint32_t b2 = get_32bits(nfsr, 2);
-  const uint32_t b15 = get_32bits(nfsr, 15);
-  const uint32_t b36 = get_32bits(nfsr, 36);
-  const uint32_t b45 = get_32bits(nfsr, 45);
-  const uint32_t b64 = get_32bits(nfsr, 64);
-  const uint32_t b73 = get_32bits(nfsr, 73);
-  const uint32_t b89 = get_32bits(nfsr, 89);
+  const uint32_t b2 = get_32bits<2ul>(nfsr);
+  const uint32_t b15 = get_32bits<15ul>(nfsr);
+  const uint32_t b36 = get_32bits<36ul>(nfsr);
+  const uint32_t b45 = get_32bits<45ul>(nfsr);
+  const uint32_t b64 = get_32bits<64ul>(nfsr);
+  const uint32_t b73 = get_32bits<73ul>(nfsr);
+  const uint32_t b89 = get_32bits<89ul>(nfsr);
 
   const uint32_t bt = b2 ^ b15 ^ b36 ^ b45 ^ b64 ^ b73 ^ b89;
 
@@ -279,12 +281,12 @@ ksbx32(const state_t* const st)
 inline static uint8_t
 l(const state_t* const st)
 {
-  const uint8_t s0 = get_8bits(st->lfsr, 0);
-  const uint8_t s7 = get_8bits(st->lfsr, 7);
-  const uint8_t s38 = get_8bits(st->lfsr, 38);
-  const uint8_t s70 = get_8bits(st->lfsr, 70);
-  const uint8_t s81 = get_8bits(st->lfsr, 81);
-  const uint8_t s96 = get_8bits(st->lfsr, 96);
+  const uint8_t s0 = get_8bits<0ul>(st->lfsr);
+  const uint8_t s7 = get_8bits<7ul>(st->lfsr);
+  const uint8_t s38 = get_8bits<38ul>(st->lfsr);
+  const uint8_t s70 = get_8bits<70ul>(st->lfsr);
+  const uint8_t s81 = get_8bits<81ul>(st->lfsr);
+  const uint8_t s96 = get_8bits<96ul>(st->lfsr);
 
   const uint8_t res = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
   return res;
@@ -303,12 +305,12 @@ lx32(const state_t* const st)
                          from_le_bytes<uint32_t>(st->lfsr + 8ul),
                          from_le_bytes<uint32_t>(st->lfsr + 12ul) };
 
-  const uint32_t s0 = get_32bits(lfsr, 0);
-  const uint32_t s7 = get_32bits(lfsr, 7);
-  const uint32_t s38 = get_32bits(lfsr, 38);
-  const uint32_t s70 = get_32bits(lfsr, 70);
-  const uint32_t s81 = get_32bits(lfsr, 81);
-  const uint32_t s96 = get_32bits(lfsr, 96);
+  const uint32_t s0 = get_32bits<0ul>(lfsr);
+  const uint32_t s7 = get_32bits<7ul>(lfsr);
+  const uint32_t s38 = get_32bits<38ul>(lfsr);
+  const uint32_t s70 = get_32bits<70ul>(lfsr);
+  const uint32_t s81 = get_32bits<81ul>(lfsr);
+  const uint32_t s96 = get_32bits<96ul>(lfsr);
 
   const uint32_t res = s0 ^ s7 ^ s38 ^ s70 ^ s81 ^ s96;
   return res;
@@ -322,47 +324,47 @@ lx32(const state_t* const st)
 inline static uint8_t
 f(const state_t* const st)
 {
-  const uint8_t s0 = get_8bits(st->lfsr, 0);
+  const uint8_t s0 = get_8bits<0ul>(st->lfsr);
 
-  const uint8_t b0 = get_8bits(st->nfsr, 0);
-  const uint8_t b26 = get_8bits(st->nfsr, 26);
-  const uint8_t b56 = get_8bits(st->nfsr, 56);
-  const uint8_t b91 = get_8bits(st->nfsr, 91);
-  const uint8_t b96 = get_8bits(st->nfsr, 96);
+  const uint8_t b0 = get_8bits<0ul>(st->nfsr);
+  const uint8_t b26 = get_8bits<26ul>(st->nfsr);
+  const uint8_t b56 = get_8bits<56ul>(st->nfsr);
+  const uint8_t b91 = get_8bits<91ul>(st->nfsr);
+  const uint8_t b96 = get_8bits<96ul>(st->nfsr);
 
-  const uint8_t b3 = get_8bits(st->nfsr, 3);
-  const uint8_t b67 = get_8bits(st->nfsr, 67);
+  const uint8_t b3 = get_8bits<3ul>(st->nfsr);
+  const uint8_t b67 = get_8bits<67ul>(st->nfsr);
 
-  const uint8_t b11 = get_8bits(st->nfsr, 11);
-  const uint8_t b13 = get_8bits(st->nfsr, 13);
+  const uint8_t b11 = get_8bits<11ul>(st->nfsr);
+  const uint8_t b13 = get_8bits<13ul>(st->nfsr);
 
-  const uint8_t b17 = get_8bits(st->nfsr, 17);
-  const uint8_t b18 = get_8bits(st->nfsr, 18);
+  const uint8_t b17 = get_8bits<17ul>(st->nfsr);
+  const uint8_t b18 = get_8bits<18ul>(st->nfsr);
 
-  const uint8_t b27 = get_8bits(st->nfsr, 27);
-  const uint8_t b59 = get_8bits(st->nfsr, 59);
+  const uint8_t b27 = get_8bits<27ul>(st->nfsr);
+  const uint8_t b59 = get_8bits<59ul>(st->nfsr);
 
-  const uint8_t b40 = get_8bits(st->nfsr, 40);
-  const uint8_t b48 = get_8bits(st->nfsr, 48);
+  const uint8_t b40 = get_8bits<40ul>(st->nfsr);
+  const uint8_t b48 = get_8bits<48ul>(st->nfsr);
 
-  const uint8_t b61 = get_8bits(st->nfsr, 61);
-  const uint8_t b65 = get_8bits(st->nfsr, 65);
+  const uint8_t b61 = get_8bits<61ul>(st->nfsr);
+  const uint8_t b65 = get_8bits<65ul>(st->nfsr);
 
-  const uint8_t b68 = get_8bits(st->nfsr, 68);
-  const uint8_t b84 = get_8bits(st->nfsr, 84);
+  const uint8_t b68 = get_8bits<68ul>(st->nfsr);
+  const uint8_t b84 = get_8bits<84ul>(st->nfsr);
 
-  const uint8_t b22 = get_8bits(st->nfsr, 22);
-  const uint8_t b24 = get_8bits(st->nfsr, 24);
-  const uint8_t b25 = get_8bits(st->nfsr, 25);
+  const uint8_t b22 = get_8bits<22ul>(st->nfsr);
+  const uint8_t b24 = get_8bits<24ul>(st->nfsr);
+  const uint8_t b25 = get_8bits<25ul>(st->nfsr);
 
-  const uint8_t b70 = get_8bits(st->nfsr, 70);
-  const uint8_t b78 = get_8bits(st->nfsr, 78);
-  const uint8_t b82 = get_8bits(st->nfsr, 82);
+  const uint8_t b70 = get_8bits<70ul>(st->nfsr);
+  const uint8_t b78 = get_8bits<78ul>(st->nfsr);
+  const uint8_t b82 = get_8bits<82ul>(st->nfsr);
 
-  const uint8_t b88 = get_8bits(st->nfsr, 88);
-  const uint8_t b92 = get_8bits(st->nfsr, 92);
-  const uint8_t b93 = get_8bits(st->nfsr, 93);
-  const uint8_t b95 = get_8bits(st->nfsr, 95);
+  const uint8_t b88 = get_8bits<88ul>(st->nfsr);
+  const uint8_t b92 = get_8bits<92ul>(st->nfsr);
+  const uint8_t b93 = get_8bits<93ul>(st->nfsr);
+  const uint8_t b95 = get_8bits<95ul>(st->nfsr);
 
   const uint8_t t0 = b0 ^ b26 ^ b56 ^ b91 ^ b96;
   const uint8_t t1 = b3 & b67;
@@ -396,45 +398,45 @@ fx32(const state_t* const st)
 
   const uint32_t s0 = from_le_bytes<uint32_t>(st->lfsr + 0ul);
 
-  const uint32_t b0 = get_32bits(nfsr, 0);
-  const uint32_t b26 = get_32bits(nfsr, 26);
-  const uint32_t b56 = get_32bits(nfsr, 56);
-  const uint32_t b91 = get_32bits(nfsr, 91);
-  const uint32_t b96 = get_32bits(nfsr, 96);
+  const uint32_t b0 = get_32bits<0ul>(nfsr);
+  const uint32_t b26 = get_32bits<26ul>(nfsr);
+  const uint32_t b56 = get_32bits<56ul>(nfsr);
+  const uint32_t b91 = get_32bits<91ul>(nfsr);
+  const uint32_t b96 = get_32bits<96ul>(nfsr);
 
-  const uint32_t b3 = get_32bits(nfsr, 3);
-  const uint32_t b67 = get_32bits(nfsr, 67);
+  const uint32_t b3 = get_32bits<3ul>(nfsr);
+  const uint32_t b67 = get_32bits<67ul>(nfsr);
 
-  const uint32_t b11 = get_32bits(nfsr, 11);
-  const uint32_t b13 = get_32bits(nfsr, 13);
+  const uint32_t b11 = get_32bits<11ul>(nfsr);
+  const uint32_t b13 = get_32bits<13ul>(nfsr);
 
-  const uint32_t b17 = get_32bits(nfsr, 17);
-  const uint32_t b18 = get_32bits(nfsr, 18);
+  const uint32_t b17 = get_32bits<17ul>(nfsr);
+  const uint32_t b18 = get_32bits<18ul>(nfsr);
 
-  const uint32_t b27 = get_32bits(nfsr, 27);
-  const uint32_t b59 = get_32bits(nfsr, 59);
+  const uint32_t b27 = get_32bits<27ul>(nfsr);
+  const uint32_t b59 = get_32bits<59ul>(nfsr);
 
-  const uint32_t b40 = get_32bits(nfsr, 40);
-  const uint32_t b48 = get_32bits(nfsr, 48);
+  const uint32_t b40 = get_32bits<40ul>(nfsr);
+  const uint32_t b48 = get_32bits<48ul>(nfsr);
 
-  const uint32_t b61 = get_32bits(nfsr, 61);
-  const uint32_t b65 = get_32bits(nfsr, 65);
+  const uint32_t b61 = get_32bits<61ul>(nfsr);
+  const uint32_t b65 = get_32bits<65ul>(nfsr);
 
-  const uint32_t b68 = get_32bits(nfsr, 68);
-  const uint32_t b84 = get_32bits(nfsr, 84);
+  const uint32_t b68 = get_32bits<68ul>(nfsr);
+  const uint32_t b84 = get_32bits<84ul>(nfsr);
 
-  const uint32_t b22 = get_32bits(nfsr, 22);
-  const uint32_t b24 = get_32bits(nfsr, 24);
-  const uint32_t b25 = get_32bits(nfsr, 25);
+  const uint32_t b22 = get_32bits<22ul>(nfsr);
+  const uint32_t b24 = get_32bits<24ul>(nfsr);
+  const uint32_t b25 = get_32bits<25ul>(nfsr);
 
-  const uint32_t b70 = get_32bits(nfsr, 70);
-  const uint32_t b78 = get_32bits(nfsr, 78);
-  const uint32_t b82 = get_32bits(nfsr, 82);
+  const uint32_t b70 = get_32bits<70ul>(nfsr);
+  const uint32_t b78 = get_32bits<78ul>(nfsr);
+  const uint32_t b82 = get_32bits<82ul>(nfsr);
 
-  const uint32_t b88 = get_32bits(nfsr, 88);
-  const uint32_t b92 = get_32bits(nfsr, 92);
-  const uint32_t b93 = get_32bits(nfsr, 93);
-  const uint32_t b95 = get_32bits(nfsr, 95);
+  const uint32_t b88 = get_32bits<88ul>(nfsr);
+  const uint32_t b92 = get_32bits<92ul>(nfsr);
+  const uint32_t b93 = get_32bits<93ul>(nfsr);
+  const uint32_t b95 = get_32bits<95ul>(nfsr);
 
   const uint32_t t0 = b0 ^ b26 ^ b56 ^ b91 ^ b96;
   const uint32_t t1 = b3 & b67;

--- a/include/grain_128.hpp
+++ b/include/grain_128.hpp
@@ -611,7 +611,7 @@ authenticate(state_t* const st, // Grain-128 AEAD cipher state
     sreg = from_le_bytes<uint64_t>(st->sreg);
   }
 
-  constexpr int blen = std::numeric_limits<T>::digits;
+  constexpr size_t blen = static_cast<size_t>(std::numeric_limits<T>::digits);
 
   for (size_t i = 0; i < blen; i++) {
     const bool m = static_cast<bool>((msg >> i) & 0b1);


### PR DESCRIPTION
Previously 

- When initializing state of cipher, 32 consecutive cycles were executed in parallel
- But during encrypting/ decrypting and authenticating associated data or plain text, 8 consecutive cycles were executed in parallel

Now

- When ever possible 32 consecutive cycles are executed in parallel, generating 32 key stream bits, used for authentication & encryption/ decryption. 
- It should boost execution speed by ~3.5x ✅
- When executing 32 consecutive cycles in parallel, both 128 -bit NFSR and LFSR are interpreted as `uint32_t[4]` for ease of bit/ byte indexing.
- On x86_64 platform, if `__BMI2__` CPU featue is available then efficient `_pext_u32` intrinsic is used for extracting out even/ odd bits from uint32_t. 
- Indices which can possibly be computed in compile time are done such way.

With this, I'm seeing [these](https://github.com/itzmeanjan/grain-128aead/commit/0eaa890a9a2dae7308e405ddbb1fb91d1ae18c3b?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) improvements. 